### PR TITLE
fix: wait for settings/credentials services before session creation and first render (API Key ✗ false negative, default model used)

### DIFF
--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -686,6 +686,28 @@ export class TuiApp {
   get sessionId(): SessionId | null { return this.activeSessionId }
 
   /**
+   * A1/A2：等待若干服务完成激活（fiber state 2，即 init 钩子已跑完、文件数据
+   * 已装载）后再做首帧渲染。credentials/settings 由 dsh-base 异步激活（读文件 +
+   * watcher），可能晚于本 runner——不等的话欢迎页会误报 API Key ✗、顶栏显示
+   * 默认模型（settings 里的 agent-default-model 未生效）。
+   *
+   * 服务未注册（不在本 profile 组成中）时跳过；有界等待避免服务缺失时挂死。
+   * @param names - 要等待的服务名。
+   * @param timeoutMs - 最大等待毫秒（缺省 5000）。
+   */
+  private async waitForServicesReady(names: readonly string[], timeoutMs = 5000): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    for (const name of names) {
+      // 未注册（非严格取不到）：本 profile 无该服务，没有数据可等，直接跳过。
+      if (this.ctx.reflect.get(name, false) === undefined) continue
+      // 已注册但 fiber 未激活（init 未完成）：有界轮询等待激活完成。
+      while (this.ctx.reflect.get(name) === undefined && Date.now() < deadline) {
+        await new Promise(resolve => setTimeout(resolve, 25))
+      }
+    }
+  }
+
+  /**
    * 接管终端：切主题（'auto' 探测背景）、装配会话、注册键路由与 resize、启动渲染 ticker。
    * @param initialSessionId - 覆盖构造选项的起始会话；缺省用构造 initialSessionId，
    *   再缺省恢复最近会话（live store 为空才新建）。
@@ -707,6 +729,10 @@ export class TuiApp {
     }
 
     const target = initialSessionId ?? this.initialSessionId ?? this.ctx.sessions.list()[0]?.id
+    // A1/A2：创建/恢复会话与首帧渲染前，等 settings/credentials 服务激活
+    // （有界；未注册跳过）——否则 newSession/resume 在创建时快照到的是 config
+    // 默认模型（settings 未加载），且欢迎页误报 API Key ✗。
+    await this.waitForServicesReady(['settings', 'credentials'])
     if (target !== undefined) await this.switchSession(target)
     else await this.newSession()
 

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -4978,3 +4978,73 @@ describe('TuiApp 剪贴板图片与复制（opencode 接线移植）', () => {
     await app.dispose()
   })
 })
+
+describe('TuiApp 首帧渲染等待 settings/credentials 服务（A1/A2）', () => {
+  it('服务已注册但未激活时，attach 等待激活后再创建会话/渲染（API Key ✓ + settings 模型生效）', async () => {
+    const ctx = makeCtx()
+    const agent = makeAgent('svc-1')
+    const handle = makeHandle(agent)
+    ctx.agents.create.mockResolvedValue(handle)
+    ctx.sessions.get.mockReturnValue(agent.session)
+    ctx.sessions.list.mockReturnValue([])
+    const stdin = makeStdin()
+    const stdout = makeStdout()
+
+    // 模拟 dsh-base 的 credentials/settings：已注册（非严格可取）但 fiber 未激活
+    // （严格取不到），随后在 attach 进行中完成激活。currentSelection 在激活前
+    // 返回 config 默认值、激活后返回 settings 值（真实行为）。
+    let activated = false
+    const credentials = { describe: vi.fn(async () => ({ configured: true, source: 'file' as const, writable: true })) }
+    ctx.agentDefaultModel.currentSelection.mockImplementation(() => activated
+      ? { provider: 'deepseek-official', model: 'deepseek' }
+      : { provider: 'deepseek-official', model: 'deepseek-v4-flash' })
+    ctx.reflect.get.mockImplementation((name: string, strict = true) => {
+      if (name === 'settings') return strict ? (activated ? {} : undefined) : {}
+      if (name === 'credentials') return strict ? (activated ? credentials : undefined) : credentials
+      return undefined
+    })
+
+    const app = new TuiApp({ ctx, stdout, stdin })
+    const attachPromise = app.attach()
+    // 服务在 attach 等待窗口内激活（真实场景：文件读 + watcher 初始化，毫秒级）。
+    setTimeout(() => { activated = true }, 50)
+    await attachPromise
+
+    const written = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+    // 等待生效 → refreshApiKeyReady 经 credentials.describe 读到 configured → 欢迎页 ✓
+    expect(written).toContain('API Key ✓')
+    expect(written).not.toContain('API Key ✗')
+    // A2：会话创建时快照的是 settings 的模型（deepseek），而非 config 默认
+    // （deepseek-v4-flash）——等待发生在 newSession 之前。
+    const createArg = ctx.agents.create.mock.calls[0]?.[0] as { agentOptions?: { provider: string; model: string } } | undefined
+    expect(createArg?.agentOptions).toEqual({ provider: 'deepseek-official', model: 'deepseek' })
+    await app.dispose()
+  })
+
+  it('服务未注册（mock 缺省）时 attach 不被等待阻塞，走 env 回退（API Key ✗）', async () => {
+    // 显式清掉 DEEPSEEK_API_KEY：该用例断言 env 回退路径，宿主环境可能已设
+    // 该变量（setx 持久化等），避免测试环境相关的不稳定。
+    const prevKey = process.env.DEEPSEEK_API_KEY
+    delete process.env.DEEPSEEK_API_KEY
+    try {
+      const ctx = makeCtx()
+      const agent = makeAgent('svc-2')
+      const handle = makeHandle(agent)
+      ctx.agents.create.mockResolvedValue(handle)
+      ctx.sessions.get.mockReturnValue(agent.session)
+      ctx.sessions.list.mockReturnValue([])
+      const stdin = makeStdin()
+      const stdout = makeStdout()
+
+      const app = new TuiApp({ ctx, stdout, stdin })
+      await app.attach()
+
+      const written = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+      // 无 credentials 服务 → process.env 回退（已清空）→ ✗
+      expect(written).toContain('API Key ✗')
+      await app.dispose()
+    } finally {
+      if (prevKey !== undefined) process.env.DEEPSEEK_API_KEY = prevKey
+    }
+  })
+})


### PR DESCRIPTION
会话创建与欢迎页渲染早于 settings/credentials 服务激活：
- newSession()/resume() 在创建时快照 agentDefaultModel.currentSelection()——
  settings 未加载时快照到 config 默认模型，agent 实际按默认模型路由
- 欢迎页在 .credentials.yaml 已存 key 时仍显示 "API Key ✗（设 DEEPSEEK_API_KEY）"

根因：attach() 立即创建会话并渲染，而 credentials-local / settings-file 异步激活
（读文件 + watcher）。

修复：attach 在会话创建与首帧渲染前有界等待 settings/credentials 完成激活
（strict reflect.get = fiber ACTIVE）；服务未注册时跳过，不阻塞启动。

测试：app.spec.ts 新增 2 例（激活等待 → API Key ✓ 且 agents.create 的
agentOptions 为 settings 模型；未注册 → 不阻塞 + env 回退）。