### PR TITLE
fix: stale Waiting for response hint and stuck wrapup after a completed reply

### DIFF
--- a/src/engine/input-controller.ts
+++ b/src/engine/input-controller.ts
@@ -210,6 +210,8 @@ export class InputController {
   }
   /** 输入历史（最新在前，submit 时更新 + 持久化） */
   inputHistory: string[] = []
+  /** 空闲时空输入 Ctrl+C 连按退出的时间窗（ms）。 */
+  static readonly EXIT_WINDOW_MS = 2000
   /** Ctrl+C double-press window start timestamp (ms), 0 = inactive */
   ctrlCPendingSince = 0
   /** ESC double-press: last ESC timestamp (ms), 0 = inactive */

--- a/src/fluency-hook.ts
+++ b/src/fluency-hook.ts
@@ -37,6 +37,8 @@ export class FluencyTracker {
   private phase: ActivityPhase = 'idle'
   private outputRate = 0
   private resultLength = 0
+  /** 是否有请求在途（turn/start 置位，turn/end 复位）。false 时静默提示不触发。 */
+  private inFlight = false
 
   /**
    * 判定一次工具调用是否算 routine（只读检索类且未出错）。
@@ -80,11 +82,13 @@ export class FluencyTracker {
   }
 
   /**
-   * 切换当前活动阶段并重置静默计时起点。
+   * 切换当前活动阶段并重置静默计时起点。设置阶段意味着有活动在途
+   * （A5：静默提示仅在在途时有效；onTurnComplete 复位）。
    * @param phase - 新的活动阶段。
    */
   setPhase(phase: ActivityPhase): void {
     this.phase = phase
+    this.inFlight = true
     this.lastEventAt = Date.now()
   }
 
@@ -96,7 +100,13 @@ export class FluencyTracker {
     this.lastEventAt = Date.now() - silentMs
   }
 
-  /** 回合结束：清空全部信号并回到 idle 阶段。 */
+  /** 回合开始：标记请求在途，重置静默计时起点。静默提示仅在在途时有效。 */
+  onTurnStart(): void {
+    this.inFlight = true
+    this.lastEventAt = Date.now()
+  }
+
+  /** 回合结束：清空全部信号、复位在途标记并回到 idle 阶段。 */
   onTurnComplete(): void {
     this.routine.reset()
     this.lastIsError = false
@@ -105,6 +115,7 @@ export class FluencyTracker {
     this.resultLength = 0
     this.lastEventAt = Date.now()
     this.phase = 'idle'
+    this.inFlight = false
   }
 
   /**
@@ -121,6 +132,7 @@ export class FluencyTracker {
       isError: this.lastIsError,
       isApproval: this.lastIsApproval,
       consecutiveRoutine: this.routine.count,
+      inFlight: this.inFlight,
     }
     return computeFluencyPolicy(signals)
   }

--- a/src/format/fluency-policy.ts
+++ b/src/format/fluency-policy.ts
@@ -29,6 +29,10 @@ export interface FluencySignals {
   isError: boolean
   isApproval: boolean
   consecutiveRoutine: number
+  /** 是否有请求在途。缺省按 true 处理（兼容旧信号源）；false 时静默提示不触发——
+   *  回合结束后 agent 已 idle，silentMs 仍在增长，继续提示会把已完成的回复
+   *  谎报成 "Waiting for response"。 */
+  inFlight?: boolean
 }
 
 /** 策略输出：可见度、是否折叠例行事件、聚合窗口与可选停滞提示。 */
@@ -109,7 +113,10 @@ export function computeFluencyPolicy(signals: FluencySignals): FluencyPolicy {
   }
 
   // Silent too long → stale inspection (phase-aware thresholds)
-  if (signals.silentMs >= 15_000) {
+  // A5：仅在请求在途（inFlight !== false）时提示——turn 结束后 tracker 回到
+  // idle 但 silentMs 仍在增长，无在途请求时提示是噪音（"Waiting for response"
+  // 出现在已完成回复下方并持续计时）。
+  if (signals.silentMs >= 15_000 && signals.inFlight !== false) {
     const stale = getPhaseStaleMessage(signals.phase, signals.silentMs)
     if (stale) {
       return {

--- a/src/statusline.ts
+++ b/src/statusline.ts
@@ -275,6 +275,8 @@ export class WorkflowStatusLine {
   private approvalPolicy: 'ask' | 'never' | null = null
   /** 会话内最后一条 permission/preset 折叠值（permission 服务装配时；null = 未记录）。 */
   private permissionPreset: string | null = null
+  /** agent 是否不在 running。收尾相位在 idle 时不占状态行（否则 ◆ 收尾一直挂着像卡住）。 */
+  private agentIdle = true
   private lastText: string | null = null
   private readonly onUpdate: (text: string | null) => void
   private readonly disposers: (() => void)[]
@@ -284,6 +286,7 @@ export class WorkflowStatusLine {
     this.onUpdate = onUpdate
     const onStatus = (_payload: { agent: { id: SessionId }; status: AgentStatus }): void => {
       if (_payload.agent.id !== sessionId) return
+      this.agentIdle = _payload.status !== 'running'
       // 状态变化本身不改变阶段/活动，仅触发一次重渲染（保持 current 新鲜）。
       this.emit()
     }
@@ -335,6 +338,15 @@ export class WorkflowStatusLine {
   }
 
   private emit(): void {
+    // turn/end completed 把相位留在 wrapup（收尾）是工作流事实；agent 已 idle
+    // 时继续展示会让状态行永远停在 ◆ 收尾，像请求还在途。空闲不占位。
+    if (this.agentIdle && this.view.phase === 'wrapup') {
+      if (this.lastText !== null) {
+        this.lastText = null
+        this.onUpdate(null)
+      }
+      return
+    }
     const text = formatStatusLine(
       this.view,
       this.planState.active,

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -1964,6 +1964,9 @@ export class TuiApp {
 
   /** 键路由：Enter 提交 / Ctrl-C 取消或退出 / 上下键历史 / 其余交给 InputLine。 */
   private handleKey(key: KeyPress): void {
+    if (key.name !== 'ctrl_c' && this.inputController.ctrlCPendingSince !== 0) {
+      this.inputController.ctrlCPendingSince = 0
+    }
     // C3 项 4：Shift+Tab 三态循环（Normal → Plan → Always-Approve → Normal）。
     if (key.name === 'shift_tab') {
       this.cycleMode()
@@ -1971,7 +1974,7 @@ export class TuiApp {
     }
     // C4 概念稿 A：欢迎页菜单入口快捷键——新会话 / 恢复会话 / 退出。
     // 语义与菜单行提示一致（grok menu.rs 的 ctrl+w/ctrl+s/ctrl+q 对齐）；
-    // 任意时刻可用（新会话即 /session new 语义，退出即 Ctrl+C 空输入退出）。
+    // 任意时刻可用（新会话即 /session new 语义，退出即 Ctrl+Q / 连按两次 Ctrl+C）。
     // 注意：ctrl_n 在此劫持 InputLine 的 historyNext（L791）、ctrl_p 早已被
     // 命令面板劫持（historyPrev）——输入历史导航由 ↑/↓ 承担，此处不留键。
     if (key.name === 'ctrl_n') {
@@ -2144,12 +2147,27 @@ export class TuiApp {
       return
     }
     if (key.name === 'ctrl_c') {
-      // raw-mode 下 Ctrl+C 是 0x03 数据字节而非 SIGINT——退出路径走这里：
-      // 输入为空退出（onExit），有输入取消当前活动（handleAbort）。
-      if (this.inputLine.value === '' && this.onExit !== undefined) {
-        this.onExit()
+      // raw-mode 下 Ctrl+C 是 0x03 数据字节而非 SIGINT。
+      // 在途：打断当前 turn。空闲空输入：连按两次才 onExit（单次 dispose
+      // 会拆掉 TUI 而 dsh 进程仍在，表现为“按 Ctrl+C 后无法继续、只能再按一次退出”）。
+      if (this.liveAgent?.state.status === 'running') {
+        this.inputController.ctrlCPendingSince = 0
+        this.handleAbort()
         return
       }
+      if (this.inputLine.value === '' && this.onExit !== undefined) {
+        const now = Date.now()
+        const pending = this.inputController.ctrlCPendingSince
+        if (pending !== 0 && now - pending < InputController.EXIT_WINDOW_MS) {
+          this.inputController.ctrlCPendingSince = 0
+          this.onExit()
+          return
+        }
+        this.inputController.ctrlCPendingSince = now
+        this.flushLiveRender()
+        return
+      }
+      this.inputController.ctrlCPendingSince = 0
       this.handleAbort()
       return
     }
@@ -2592,6 +2610,14 @@ export class TuiApp {
         ? theme.error
         : policy.staleLevel === 'warn' ? theme.warning : theme.secondary
       lines.push({ text: color(`⏳ ${policy.staleMessage}`, staleColor) })
+    }
+    const ctrlCPendingSince = this.inputController.ctrlCPendingSince
+    if (ctrlCPendingSince !== 0) {
+      if (Date.now() - ctrlCPendingSince >= InputController.EXIT_WINDOW_MS) {
+        this.inputController.ctrlCPendingSince = 0
+      } else {
+        lines.push({ text: color('再按 Ctrl+C 退出 · Ctrl+Q 立即退出', theme.muted) })
+      }
     }
 
     // 推理展开视图（Ctrl+O 切换；scrollback append-only，全文在 live 区展示）：

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -2354,6 +2354,10 @@ export class TuiApp {
         this.commitSettledToolCard(event)
         break
       }
+      case 'turn/start':
+        // A5：回合开始 → 标记请求在途，静默提示生效（turn/end 由 onTurnComplete 复位）。
+        this.fluency.onTurnStart()
+        break
       case 'turn/end':
         // Phase 9d：turn 边界复位流利度信号
         this.fluency.onTurnComplete()

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -471,9 +471,36 @@ describe('TuiApp 审查 HIGH 修复回归（177c12e）', () => {
     await app.dispose()
   })
 
-  it('ctrl_c 空输入触发 onExit 而非取消', async () => {
+  it('ctrl_c 空闲空输入：第一次不退出，窗口内第二次才 onExit', async () => {
     const ctx = makeCtx()
     const agent = makeAgent('exit-1')
+    const handle = makeHandle(agent)
+    ctx.agents.create.mockResolvedValue(handle)
+    ctx.sessions.get.mockReturnValue(agent.session)
+    const onExit = vi.fn()
+    const stdin = makeStdin()
+    const stdout = makeStdout()
+
+    const app = new TuiApp({ ctx, stdout, stdin, onExit })
+    await app.attach()
+
+    stdin.emit('data', '\x03')
+    await new Promise(resolve => setImmediate(resolve))
+    expect(onExit).not.toHaveBeenCalled()
+    expect(agent.cancel).not.toHaveBeenCalled()
+    const afterFirst = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+    expect(afterFirst).toContain('再按 Ctrl+C 退出')
+
+    stdin.emit('data', '\x03')
+    await new Promise(resolve => setImmediate(resolve))
+    expect(onExit).toHaveBeenCalledTimes(1)
+    expect(agent.cancel).not.toHaveBeenCalled()
+    await app.dispose()
+  })
+
+  it('ctrl_c 空闲空输入：超过 double-press 窗口的第二次仍不退出', async () => {
+    const ctx = makeCtx()
+    const agent = makeAgent('exit-window')
     const handle = makeHandle(agent)
     ctx.agents.create.mockResolvedValue(handle)
     ctx.sessions.get.mockReturnValue(agent.session)
@@ -483,11 +510,46 @@ describe('TuiApp 审查 HIGH 修复回归（177c12e）', () => {
     const app = new TuiApp({ ctx, stdout: makeStdout(), stdin, onExit })
     await app.attach()
 
-    stdin.emit('data', '\x03') // raw-mode Ctrl+C 作为 0x03 字节进入数据流
+    const now = Date.now()
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now)
+    stdin.emit('data', '\x03')
     await new Promise(resolve => setImmediate(resolve))
-
+    nowSpy.mockReturnValue(now + 2_001)
+    stdin.emit('data', '\x03')
+    await new Promise(resolve => setImmediate(resolve))
+    expect(onExit).not.toHaveBeenCalled()
+    nowSpy.mockReturnValue(now + 2_002)
+    stdin.emit('data', '\x03')
+    await new Promise(resolve => setImmediate(resolve))
     expect(onExit).toHaveBeenCalledTimes(1)
-    expect(agent.cancel).not.toHaveBeenCalled()
+    await app.dispose()
+  })
+
+  it('agent running 时空输入 Ctrl+C → handleAbort，不 onExit', async () => {
+    const ctx = makeCtx()
+    const agent = makeAgent('abort-run')
+    const handle = makeHandle(agent)
+    ctx.agents.create.mockResolvedValue(handle)
+    ctx.sessions.get.mockReturnValue(agent.session)
+    const onExit = vi.fn()
+    const stdin = makeStdin()
+    const stdout = makeStdout()
+
+    const app = new TuiApp({ ctx, stdout, stdin, onExit })
+    await app.attach()
+    const id = app.sessionId
+    if (id === undefined) throw new Error('sessionId missing after attach')
+    const statusHandlers = (ctx.on as ReturnType<typeof vi.fn>).mock.calls
+      .filter((call: unknown[]) => call[0] === 'agent/status')
+      .map(call => call[1] as (payload: { agent: { id: SessionId }; status: string }) => void)
+    for (const handler of statusHandlers) handler({ agent: { id }, status: 'running' })
+
+    stdin.emit('data', '\x03')
+    await new Promise(resolve => setImmediate(resolve))
+    expect(onExit).not.toHaveBeenCalled()
+    expect(agent.cancel).toHaveBeenCalledTimes(1)
+    const written = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+    expect(written).toContain('已取消')
     await app.dispose()
   })
 

--- a/tests/fluency.spec.ts
+++ b/tests/fluency.spec.ts
@@ -55,6 +55,18 @@ describe('computeFluencyPolicy', () => {
     expect(policy.staleMessage).toBeUndefined()
   })
 
+  it('A5：inFlight=false（回合已结束）时静默超时也不触发 stale', () => {
+    const policy = computeFluencyPolicy(base({ phase: 'idle', silentMs: 200_000, inFlight: false }))
+    expect(policy.staleMessage).toBeUndefined()
+    expect(policy.visibility).toBe('normal')
+  })
+
+  it('A5：inFlight 缺省（在途）时 idle 静默超时仍触发 stale（初始等待场景）', () => {
+    const policy = computeFluencyPolicy(base({ phase: 'idle', silentMs: 20_000 }))
+    expect(policy.staleMessage).toContain('Waiting for response')
+    expect(policy.staleLevel).toBe('info')
+  })
+
   it('大结果 / 高速率 → inspect 折叠 coalesce 1s', () => {
     const policy = computeFluencyPolicy(base({ resultLength: 60_000 }))
     expect(policy).toEqual({ visibility: 'inspect', foldRoutine: true, coalesceMs: 1000 })
@@ -214,5 +226,21 @@ describe('FluencyTracker', () => {
     tracker.recordToolResult({ name: 'read_file', isError: false, resultLength: 1000 })
     tracker.onTurnComplete()
     expect(tracker.getPolicy()).toEqual({ visibility: 'normal', foldRoutine: false, coalesceMs: 0 })
+  })
+
+  it('A5：onTurnStart 置在途 → 静默提示生效；onTurnComplete 复位后不再触发', () => {
+    const tracker = new FluencyTracker()
+    // 初始不在途：静默再久也不提示（欢迎页/空闲场景）
+    tracker.updateSilence(200_000)
+    expect(tracker.getPolicy().staleMessage).toBeUndefined()
+    // 回合开始 → 在途 → 静默提示恢复
+    tracker.onTurnStart()
+    tracker.updateSilence(20_000)
+    expect(tracker.getPolicy().staleMessage).toContain('Waiting for response')
+    expect(tracker.getPolicy().staleLevel).toBe('info')
+    // 回合结束 → 复位 → 静默提示消失
+    tracker.onTurnComplete()
+    tracker.updateSilence(200_000)
+    expect(tracker.getPolicy().staleMessage).toBeUndefined()
   })
 })

--- a/tests/statusline.spec.ts
+++ b/tests/statusline.spec.ts
@@ -293,4 +293,37 @@ describe('WorkflowStatusLine (自包含事件订阅)', () => {
     expect(updates).toHaveLength(0)
     expect(line.current).toBeNull()
   })
+
+  it('A5：turn/end 收尾在 agent idle 时不占据状态行（回到空闲不占位）', () => {
+    const { ctx, handlers } = fakeCtx()
+    const updates: (string | null)[] = []
+    const line = new WorkflowStatusLine(ctx, sid, text => updates.push(text))
+    const sessionHandler = handlers.get('session/event')?.[0]
+    if (sessionHandler === undefined) throw new Error('session/event handler not registered')
+
+    sessionHandler({ id: sid }, turnStart(1, 1))
+    sessionHandler({ id: sid }, turnEnd(2, 1))
+    // agent 默认 idle：收尾相位保留在视图里，但状态行回到空闲（null，不占位）。
+    expect(updates[updates.length - 1]).toBeNull()
+    expect(line.current).toBeNull()
+  })
+
+  it('A5：agent running 时 turn/end 仍显示收尾；idle 后清除', () => {
+    const { ctx, handlers } = fakeCtx()
+    const updates: (string | null)[] = []
+    const line = new WorkflowStatusLine(ctx, sid, text => updates.push(text))
+    const sessionHandler = handlers.get('session/event')?.[0]
+    const statusHandler = handlers.get('agent/status')?.[0]
+    if (sessionHandler === undefined) throw new Error('session/event handler not registered')
+    if (statusHandler === undefined) throw new Error('agent/status handler not registered')
+
+    statusHandler({ agent: { id: sid }, status: 'running' })
+    sessionHandler({ id: sid }, turnStart(1, 1))
+    sessionHandler({ id: sid }, turnEnd(2, 1))
+    expect(line.current).toContain('收尾')
+
+    statusHandler({ agent: { id: sid }, status: 'idle' })
+    expect(line.current).toBeNull()
+    expect(updates[updates.length - 1]).toBeNull()
+  })
 })


### PR DESCRIPTION
每次回复完成后会出现两层假"还在跑"：
- 状态行停在 ◆ 收尾不消失
- 闲置 15s 后出现 Waiting for response 并涨到 No response — Ctrl+C to interrupt
- 按提示 Ctrl+C 会拆掉 TUI，dsh 进程仍在，只能再按一次才能退出

根因：
- turn/end 后 FluencyTracker 回到 idle 但 silentMs 继续增长，stale 无在途判定
- 工作流相位留在 wrapup，glance 一直渲染收尾
- 空闲空输入 Ctrl+C 直接 onExit/dispose

修复：
- tracker inFlight（turn/start 置位、turn/end 复位）；仅 inFlight !== false 时 stale
- agent idle 且相位 wrapup 时状态行不占位（view 仍保留 wrapup）
- 在途 Ctrl+C → abort；空闲空输入 2s 内连按两次才退出（Ctrl+Q 仍立即退出）

测试：fluency.spec.ts + statusline idle/wrapup + app.spec Ctrl+C 连按/在途 abort。