### PR TITLE
fix: full-screen overlays get overwritten by streamed output

### DIFF
--- a/src/engine/live-engine.ts
+++ b/src/engine/live-engine.ts
@@ -183,14 +183,17 @@ export class LiveEngine {
   // ── CPR 自愈 ──────────────────────────────────────────────────
 
   /**
-   * 暂停 CPR 污染检测。overlay（picker/pager 等）激活期间光标在 alt screen，
-   * CPR 响应的位置不代表主屏 live region，若照常比对会误判污染并触发 renderLive
-   * 把主屏帧写进 alt screen（picker 残影泄漏回主会话的根因）。
+   * 暂停 CPR 污染检测，并禁止 render/clear 写 stdout。
+   * overlay（picker/pager 等）激活期间光标在 alt screen，CPR 响应的位置不代表
+   * 主屏 live region；若照常比对会误判污染并触发 renderLive 把主屏帧写进 alt
+   * screen（picker 残影泄漏回主会话的根因）。即便上层漏跳过 renderLive，引擎
+   * 层也不得改写 alt screen，且不得把主屏 lastDisplayRows 清零（否则退出后
+   * 会当空区再 append 一份 live 区）。
    * 调用方应在 overlay 激活时 suppress，退出时 resume（并作废基线等下一帧重建）。
    */
   private probeSuppressed = false
 
-  /** overlay 激活：暂停探针发送与污染判定。 */
+  /** overlay 激活：暂停探针发送与污染判定，render/clear 不再写屏。 */
   suppressProbe(): void {
     this.probeSuppressed = true
     this.cprProbePending = false
@@ -368,6 +371,8 @@ export class LiveEngine {
    * @param opts - reservedTail：超预算截断时恒保留的尾部行数（chrome 保护）
    */
   render(lines: readonly LiveRegionLine[], opts?: { reservedTail?: number }): void {
+    // alt screen 期间主屏 live 区是冻结快照：不写 stdout，也不更新几何。
+    if (this.probeSuppressed) return
     const bounded = this.applyRowBudget(this.normalizeLines(lines), opts?.reservedTail)
     const parking = this.computeParking(bounded)
 
@@ -641,6 +646,7 @@ export class LiveEngine {
    * 区域起始处。后续 append/commit 从这里开始写，干净无空白带。
    */
   clear(): void {
+    if (this.probeSuppressed) return
     this.reconcileWidth()
     if (this.lastDisplayRows === 0) return
     this.stdout.write(ANSI.HIDE_CURSOR + this.moveToTop(this.lastDisplayRows - this.parkedRowsUp) + '\r' + ANSI.ERASE_SCREEN_END)

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -2467,6 +2467,10 @@ export class TuiApp {
   /** 渲染一帧 live 区：状态行 + 流式尾巴 + 进行中工具卡 + 输入行。 */
   private renderLive(): void {
     if (this.disposed) return
+    // A6：全屏 overlay（命令面板/快捷键/搜索/rewind/memory）激活时处于
+    // alternate screen buffer——跳过主屏 live 写屏，避免流式帧逐帧盖住面板；
+    // overlay 退出后 120ms ticker 下一帧自然重绘，内部状态由事件驱动照常更新。
+    if (this.overlay !== null && this.overlay.activeId() !== null) return
     const renderStart = performance.now()
     const theme = this.theme
     const termCols = this.stdout.columns

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -2101,7 +2101,13 @@ export class TuiApp {
     // 面板打开：↑/↓ 移动选中，字符进面板查询，Enter 提交回填输入行。
     // type/move 后 rerender——overlay 无自动 ticker，不重绘则过滤/选中不刷新。
     if (this.palette?.isOpen() === true) {
-      if (key.name === 'return') {
+      if (key.name === 'escape' || key.name === 'ctrl_c') {
+        // 真机 A6：Esc/Ctrl+C 关闭面板（与 search/memory overlay 一致），不提交、
+        // 不回填输入行。此前只有 Enter 能关闭（会把 /命令 回填进输入行），
+        // Esc 被三个分支漏掉后直接 return 吞掉——面板底栏却提示 "Esc 关闭"。
+        this.overlay?.deactivate()
+        this.palette.close()
+      } else if (key.name === 'return') {
         const committed = this.palette.commit()
         this.overlay?.deactivate()
         this.palette.close()

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -371,6 +371,11 @@ export class TuiApp {
   /** API key 就绪标志（footer 右侧段；attach 时经 credentials.describe 刷新）。 */
   private apiKeyReady = Boolean(process.env.DEEPSEEK_API_KEY)
   private overlay: OverlayController | null = null
+  /**
+   * overlay 激活期间暂存的 scrollback 条目。alt screen 下 stdout 写入会盖住
+   * 面板，且退出时终端恢复的是进入 overlay 前的主屏。
+   */
+  private deferredScrollback: Array<{ text: string; trailingNewline?: boolean }> = []
   /** C3 项 3：rewind overlay（/rewind 双阶段回退面板）。 */
   private rewindOverlay: RewindOverlay | null = null
   /** P2：memory 浏览器 overlay（/memory 记忆列表/过滤/删除）。 */
@@ -716,6 +721,11 @@ export class TuiApp {
 
     this.resize.onResize(() => {
       this.live.setMaxRows(Math.max(8, this.stdout.rows - 1))
+      // overlay 激活时主屏 live 不写；resize 只重绘 alt screen 面板。
+      if (this.overlay !== null && this.overlay.activeId() !== null) {
+        this.overlay.rerender()
+        return
+      }
       this.flushLiveRender()
     })
     this.input.onAnyKey((key) => { this.handleKey(key) })
@@ -735,7 +745,13 @@ export class TuiApp {
       stdout: this.stdout,
       getSize: () => ({ cols: this.stdout.columns, rows: this.stdout.rows }),
       live: this.live,
-      onOverlayChange: () => { this.renderBatcher.schedule() },
+      onOverlayChange: (active) => {
+        if (active) return
+        // 退出 alt screen 后：把 overlay 期间暂存的 scrollback 补写回主屏，
+        // 再同步重绘 live 区（不能只等 120ms ticker——主屏刚恢复时 live 区是旧帧）。
+        this.flushDeferredScrollback()
+        this.flushLiveRender()
+      },
     })
     this.overlay.register('command-palette', this.palette)
     // Ctrl+. 快捷键面板（grok-build 键位清单弹层）：静态两列表，进出 alt screen。
@@ -1594,10 +1610,26 @@ export class TuiApp {
    * 不擦则文本写在光标处（live 区底部），随后 renderLive 重绘 live 区把刚写的
    * 内容覆盖——用户消息丢失根因（assistant 流式 commit 已带 clearForCommit，
    * 非流式路径缺失导致行为不对称）。
+   * overlay 激活时只入队，退出 alt screen 后再按同一协议补写。
    */
   private commitToScrollback(entry: { text: string; trailingNewline?: boolean }): void {
+    if (this.overlay !== null && this.overlay.activeId() !== null) {
+      this.deferredScrollback.push(entry)
+      return
+    }
     this.live.clearForCommit()
     this.commit.write(entry)
+  }
+
+  /** overlay 退出后把暂存条目按 mid-stream 协议写入主屏 scrollback。 */
+  private flushDeferredScrollback(): void {
+    const pending = this.deferredScrollback
+    if (pending.length === 0) return
+    this.deferredScrollback = []
+    for (const entry of pending) {
+      this.live.clearForCommit()
+      this.commit.write(entry)
+    }
   }
 
   /**

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -4978,3 +4978,30 @@ describe('TuiApp 剪贴板图片与复制（opencode 接线移植）', () => {
     await app.dispose()
   })
 })
+
+describe('TuiApp 全屏 overlay 激活时 renderLive 不写屏（A6）', () => {
+  it('打开命令面板后流式 ticker 不再把 live 帧写进 alt screen（不覆盖面板）', async () => {
+    const ctx = makeCtx()
+    const agent = makeAgent('ov-1')
+    const handle = makeHandle(agent)
+    ctx.agents.create.mockResolvedValue(handle)
+    ctx.sessions.get.mockReturnValue(agent.session)
+    const stdin = makeStdin()
+    const stdout = makeStdout()
+    const app = new TuiApp({ ctx, stdout, stdin })
+    await app.attach()
+
+    // 基线：主屏 live 帧含输入行 caret 驻停锚（\x1B[5G，见 caretCol 测试）。
+    stdout.write.mockClear()
+    // Ctrl+P（0x10）打开命令面板 → OverlayEngine 切 alternate screen。
+    stdin.emit('data', '\x10')
+    await new Promise(resolve => setTimeout(resolve, 250)) // 覆盖 2+ 个 120ms ticker 周期
+    const afterPalette = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+    // 面板确实打开（进入 alt screen）。
+    expect(afterPalette).toContain('\x1B[?1049h')
+    // A6：overlay 激活时 renderLive 被跳过——ticker 周期内不再出现主屏 live
+    // 帧（caret 锚）。未修复时流式帧会逐帧写进 alt screen 盖住面板。
+    expect(afterPalette).not.toContain('\x1B[5G')
+    await app.dispose()
+  })
+})

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -5004,4 +5004,48 @@ describe('TuiApp 全屏 overlay 激活时 renderLive 不写屏（A6）', () => {
     expect(afterPalette).not.toContain('\x1B[5G')
     await app.dispose()
   })
+
+  it('overlay 激活时 scrollback commit 不写进 alt screen，关闭后补写主屏', async () => {
+    const ctx = makeCtx()
+    const handlers = new Map<string, Array<(...args: unknown[]) => void>>()
+    ctx.on.mockImplementation((name: string, h: (...args: unknown[]) => void) => {
+      const list = handlers.get(name) ?? []
+      list.push(h)
+      handlers.set(name, list)
+      return () => { /* disposer: attach 路径由 app.dispose 覆盖 */ }
+    })
+    const agent = makeAgent('ov-commit')
+    ctx.agents.create.mockResolvedValue(makeHandle(agent))
+    ctx.sessions.get.mockReturnValue(agent.session)
+    const stdin = makeStdin()
+    const stdout = makeStdout()
+    const app = new TuiApp({ ctx, stdout, stdin })
+    await app.attach()
+    const owner = { id: app.sessionId ?? SessionId('ov-commit') }
+
+    stdin.emit('data', '\x10')
+    await new Promise(resolve => setTimeout(resolve, 50))
+    stdout.write.mockClear()
+
+    const sessionHandlers = handlers.get('session/event') ?? []
+    for (const handler of sessionHandlers) {
+      handler(owner, {
+        type: 'assistant/chunk',
+        seq: 0,
+        time: 1,
+        data: { turn: 1, step: 0, chunk: { type: 'text-delta', text: '先看目录。\n\n' } },
+      })
+    }
+    // blockWriter idleMs 180 + StreamRenderer 稳定边界 commit + 帧合并。
+    await new Promise(resolve => setTimeout(resolve, 300))
+    const duringOverlay = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+    expect(duringOverlay).not.toContain('先看目录')
+
+    stdout.write.mockClear()
+    stdin.emit('data', '\x10')
+    await new Promise(resolve => setTimeout(resolve, 50))
+    const afterClose = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+    expect(afterClose).toContain('先看目录')
+    await app.dispose()
+  })
 })

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -1921,6 +1921,34 @@ describe('TuiApp 命令面板（Ctrl+P overlay）', () => {
     await app.dispose()
   })
 
+  it('Esc 关闭面板（不提交、不回填输入行——底栏 "Esc 关闭" 提示真实生效）', async () => {
+    const { app, stdin, stdout } = await bootPaletteApp()
+
+    stdin.emit('data', '\x10') // Ctrl+P 打开
+    await new Promise(resolve => setImmediate(resolve))
+    stdin.emit('data', '\x1b') // Esc：input-handler 经 escapeTimeoutMs(80ms) 后派发 'escape'
+    await new Promise(resolve => setTimeout(resolve, 200)) // 等派发 + ticker 补绘主屏
+
+    const written = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+    expect(written).toContain('\x1B[?1049l')  // 退出 alternate screen buffer（面板已关闭）
+    expect(written).not.toContain('❯ /theme') // 未提交：输入行不出现 /命令 回填
+    await app.dispose()
+  })
+
+  it('Ctrl+C 关闭面板（与 Esc 同分支，不提交）', async () => {
+    const { app, stdin, stdout } = await bootPaletteApp()
+
+    stdin.emit('data', '\x10') // Ctrl+P 打开
+    await new Promise(resolve => setImmediate(resolve))
+    stdin.emit('data', '\x03') // Ctrl+C → 关闭面板（消费在面板块，不触发退出）
+    await new Promise(resolve => setTimeout(resolve, 200))
+
+    const written = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+    expect(written).toContain('\x1B[?1049l')
+    expect(written).not.toContain('❯ /theme')
+    await app.dispose()
+  })
+
   it('↓ 移动选中，Enter 回填第二项（方向键选择路径）', async () => {
     const { app, stdin, stdout } = await bootPaletteApp()
 

--- a/tests/live-engine.spec.ts
+++ b/tests/live-engine.spec.ts
@@ -5,8 +5,23 @@
  * budget ≤ 0 原样返回。
  */
 
+import type { WriteStream } from 'node:tty'
 import { describe, expect, it } from 'vitest'
-import { padDynamicRegion, type LiveRegionLine } from '../src/engine/live-engine.js'
+import { LiveEngine, padDynamicRegion, type LiveRegionLine } from '../src/engine/live-engine.js'
+
+/** 记录 stdout 写入的 LiveEngine 替身终端。 */
+function makeLiveStdout(): { stdout: WriteStream; writes: string[] } {
+  const writes: string[] = []
+  const stdout = {
+    columns: 80,
+    rows: 24,
+    write: (chunk: string) => {
+      writes.push(String(chunk))
+      return true
+    },
+  } as unknown as WriteStream
+  return { stdout, writes }
+}
 
 function L(...texts: string[]): LiveRegionLine[] {
   return texts.map(text => ({ text }))
@@ -72,5 +87,47 @@ describe('padDynamicRegion', () => {
     )
     // drop wide (3 rows) → keep=1，不垫空行补到 2
     expect(lines.map(l => l.text)).toEqual(['keep', '❯'])
+  })
+})
+
+describe('LiveEngine suppressProbe 期间不写 stdout（overlay 引擎层闸）', () => {
+  it('suppressProbe 后 render 不把主屏帧写进 stdout', () => {
+    const { stdout, writes } = makeLiveStdout()
+    const live = new LiveEngine({ stdout })
+    live.render([{ text: 'hello' }])
+    expect(writes.join('')).toContain('hello')
+    writes.length = 0
+
+    live.suppressProbe()
+    live.render([{ text: 'ghost-into-alt' }])
+    expect(writes).toHaveLength(0)
+  })
+
+  it('suppressProbe 后 clear / clearForCommit 不擦屏、不改主屏几何', () => {
+    const { stdout, writes } = makeLiveStdout()
+    const live = new LiveEngine({ stdout })
+    live.render([{ text: 'hello' }])
+    live.suppressProbe()
+    writes.length = 0
+    live.clear()
+    live.clearForCommit()
+    expect(writes).toHaveLength(0)
+
+    live.resumeProbe()
+    writes.length = 0
+    live.render([{ text: 'hello' }])
+    // 主屏 live 区仍是 overlay 进入前的帧：H2 短路，不得当空区再 append 一份。
+    expect(writes).toHaveLength(0)
+  })
+
+  it('resumeProbe 后 render 恢复写屏', () => {
+    const { stdout, writes } = makeLiveStdout()
+    const live = new LiveEngine({ stdout })
+    live.suppressProbe()
+    live.render([{ text: 'hidden' }])
+    expect(writes).toHaveLength(0)
+    live.resumeProbe()
+    live.render([{ text: 'after' }])
+    expect(writes.join('')).toContain('after')
   })
 })


### PR DESCRIPTION
输出过程中按 ctrl+p 打开命令面板，流式输出逐帧盖住面板，无法查看/选择。
影响所有全屏 overlay（command-palette/keymap/search/rewind/memory）。

根因：overlay 切到 alternate screen 后，renderLive 仍写主屏 live 帧；更关键的是
commitToScrollback 仍 clearForCommit + stdout.write，文字写进 alt screen，
退出 overlay 时主屏恢复的是进入前的内容，期间段落丢失。即便上层漏跳过
renderLive，LiveEngine.render/clear 在 suppressProbe 期间也会写进 alt screen。

修复：
- renderLive 在 overlay 激活时跳过写屏
- overlay 期间 scrollback 入队，退出 alt screen 后再按原协议补写并 flushLiveRender
- overlay 激活时 resize 只 overlay.rerender()
- LiveEngine：suppressProbe 期间 render/clear/clearForCommit 不写 stdout、不改主屏几何

测试：app.spec.ts 打开面板后 ticker 周期无 caret 锚；流式 commit 不出现在
alt screen，退出后才进主屏。live-engine.spec.ts：suppressProbe 期间零写入。

真机补充修复（702836d）：
- 命令面板 Esc/Ctrl+C 无法关闭（main 存量 bug）：面板块只处理 Enter/方向键/字符，
  Esc 被吞；只有 Enter 能关闭且会把 /命令 回填进输入行，而面板底栏提示 "Esc 关闭"
- 修复：面板块加 escape/ctrl_c 分支 → deactivate overlay + close palette，不提交、
  不回填输入行（与 search/memory overlay 一致）
- 测试：app.spec.ts 新增 Esc 关闭不回填 + Ctrl+C 关闭两例