### PR TITLE
feat: handle cmdline args (--help/--version, positional prompt)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,11 +60,13 @@ export function apply(ctx: Context, config: TuiRunnerConfig = {}): void {
   const stdout = config.stdout ?? process.stdout
   // 服务隔离：sessions/agents/agentDefaultModel/goals/subagents 是注入属性，访问前必须
   // 声明依赖（Cordis 4 注入语义，未声明访问抛 "without inject"；web-app 同款
-  // 模式）。goals/subagents 为可选服务：goal/subagent 插件未装配时注入代理不阻塞
+  // 模式）。cmdlineArgs/appExit 是 launcher 在 boot prepare 里 provide 的宿主服务，
+  // 必须 inject 后才能从 runtimeCtx 读到——reflect.get 只看插件纤维，读不到。
+  // goals/subagents 为可选服务：goal/subagent 插件未装配时注入代理不阻塞
   // 装配，/goal 命令经 reflect.get('goals')、委派树经 reflect.get('subagents')
   // 读到 undefined 时报不可用/面板降级（fails loud）。
   // 装配与 attach 在注入作用域内执行；生命周期仍注册在外层插件 ctx（随插件卸载）。
-  ctx.inject(['sessions', 'agents', 'agentDefaultModel', 'goals', 'subagents'], (runtimeCtx) => {
+  ctx.inject(['sessions', 'agents', 'agentDefaultModel', 'goals', 'subagents', 'cmdlineArgs', 'appExit'], (runtimeCtx) => {
     // 退出生命周期：stdin SIGINT、Ctrl+C 空输入（onExit）与插件卸载（effect cleanup）
     // 走同一 async dispose 路径——teardown await flushAll，退出不丢会话数据。
     // teardown 依赖 app、onExit 依赖 teardown：闭包延迟求值打破循环引用。

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -295,6 +295,37 @@ const USAGE_TEXT = `dsh-tianshu-tui — DeepSeek Harness 交互式终端界面 /
 快捷键 / Keys: ctrl+n 新会话 · ctrl+s 恢复 · ctrl+p 命令面板 · / slash 命令 · ctrl+o 展开推理 · shift+tab 模式循环
 `
 
+/** dsh launcher 在 boot prepare 里 provide 的 cmdline 面（不是插件纤维）。 */
+interface CmdlineArgsService {
+  get(): string[]
+}
+
+/**
+ * 读 launcher 转发的 argv。生产路径是 host `ctx.provide('cmdlineArgs')` + inject
+ * 后的属性；`reflect.get` 只看插件纤维，读不到这条服务（真机 --help 仍进 TUI 的根因）。
+ */
+function readCmdlineArgs(ctx: Context): string[] {
+  try {
+    const injected = (ctx as Context & { cmdlineArgs?: CmdlineArgsService }).cmdlineArgs
+    if (injected !== undefined) return injected.get()
+  } catch {
+    // Cordis 4：未 inject 时属性访问抛 without inject
+  }
+  const viaReflect = ctx.reflect.get('cmdlineArgs', false) as CmdlineArgsService | undefined
+  return viaReflect?.get() ?? []
+}
+
+/** 读 launcher 的退出请求。优先 inject 属性，其次 reflect（单测 mock）。 */
+function readAppExit(ctx: Context): ((code?: number) => void) | undefined {
+  try {
+    const injected = (ctx as Context & { appExit?: (code?: number) => void }).appExit
+    if (typeof injected === 'function') return injected
+  } catch {
+    // 同上
+  }
+  return ctx.reflect.get('appExit', false) as ((code?: number) => void) | undefined
+}
+
 /** C3 项 3：写工具名判定（与 fs-snapshot 的 trackEdit 钩子同一集合）。 */
 function isWriteToolCall(name: string): boolean {
   return name === 'write' || name === 'edit' || name === 'str_replace_editor'
@@ -709,14 +740,13 @@ export class TuiApp {
     // --help/-h 输出用法、--version/-v 输出版本后经 appExit 退出；纯位置参数
     // 作为初始 prompt（attach 完成后发送）。含其它 flag 时不发 prompt（避免
     // 与 --resume 等未实现参数的组合语义冲突）。
-    const cmdline = this.ctx.reflect.get('cmdlineArgs', false) as { get(): string[] } | undefined
-    const args = cmdline?.get() ?? []
+    const args = readCmdlineArgs(this.ctx)
     const flags = args.filter(a => a.startsWith('-'))
     const wantHelp = flags.includes('--help') || flags.includes('-h')
     const wantVersion = flags.includes('--version') || flags.includes('-v')
     const initialPrompt = flags.length === 0 ? args.filter(a => !a.startsWith('-')).join(' ') : ''
     if (wantHelp || wantVersion) {
-      const exit = this.ctx.reflect.get('appExit', false) as ((code?: number) => void) | undefined
+      const exit = readAppExit(this.ctx)
       this.stdout.write(wantHelp
         ? USAGE_TEXT
         : `dsh-tianshu-tui ${readOwnVersion(fileURLToPath(new URL('.', import.meta.url))) ?? 'unknown'}\n`)

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -21,6 +21,7 @@
 import { randomUUID } from 'node:crypto'
 import { execSync } from 'node:child_process'
 import { writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
 import { join, resolve } from 'node:path'
 import type { ReadStream, WriteStream } from 'node:tty'
 import type { Context } from '@deepseek-ai/cordis'
@@ -53,7 +54,7 @@ import { resolveToolViews, type ToolPresenterSource } from '../adapter/tool-view
 import { trackAgent, type LiveAgent } from '../adapter/live.js'
 import { controlsFromHandle, controlsFromRegistry, type AgentControls } from '../adapter/send.js'
 import { listSessions, flushAll, getSession, type SessionSummary } from '../adapter/sessions.js'
-import { updateNoticeText } from '../self-update.js'
+import { updateNoticeText, readOwnVersion } from '../self-update.js'
 import { getTheme, getActiveThemeName, setTheme, type RivetTheme } from '../theme.js'
 import { displayWidth, ambiguousWideEnabled } from '../width.js'
 import { detectTerminalBackground, autoThemeFor } from '../theme-detect.js'
@@ -281,6 +282,18 @@ export interface TuiAppOptions {
 
 /** live 区预留行（顶轨 + 输入 + 底轨 + footer）。 */
 const LIVE_RESERVED_ROWS = 4
+
+/** A3：`dsh --profile tui --help` 输出的用法文本。 */
+const USAGE_TEXT = `dsh-tianshu-tui — DeepSeek Harness 交互式终端界面 / interactive terminal UI
+
+用法 / Usage:
+  dsh --profile tui                   启动交互式 TUI / start the interactive TUI
+  dsh --profile tui "<提示词>"        启动并直接发送提示词 / start and send a prompt
+  dsh --profile tui --help            显示本帮助 / show this help
+  dsh --profile tui --version         输出版本 / print the version
+
+快捷键 / Keys: ctrl+n 新会话 · ctrl+s 恢复 · ctrl+p 命令面板 · / slash 命令 · ctrl+o 展开推理 · shift+tab 模式循环
+`
 
 /** C3 项 3：写工具名判定（与 fs-snapshot 的 trackEdit 钩子同一集合）。 */
 function isWriteToolCall(name: string): boolean {
@@ -692,6 +705,25 @@ export class TuiApp {
    */
   async attach(initialSessionId?: SessionId): Promise<void> {
     if (this.disposed) throw new Error('TuiApp already disposed')
+    // A3：处理 dsh launcher 转发的命令行参数（`dsh --profile tui <args>`）：
+    // --help/-h 输出用法、--version/-v 输出版本后经 appExit 退出；纯位置参数
+    // 作为初始 prompt（attach 完成后发送）。含其它 flag 时不发 prompt（避免
+    // 与 --resume 等未实现参数的组合语义冲突）。
+    const cmdline = this.ctx.reflect.get('cmdlineArgs', false) as { get(): string[] } | undefined
+    const args = cmdline?.get() ?? []
+    const flags = args.filter(a => a.startsWith('-'))
+    const wantHelp = flags.includes('--help') || flags.includes('-h')
+    const wantVersion = flags.includes('--version') || flags.includes('-v')
+    const initialPrompt = flags.length === 0 ? args.filter(a => !a.startsWith('-')).join(' ') : ''
+    if (wantHelp || wantVersion) {
+      const exit = this.ctx.reflect.get('appExit', false) as ((code?: number) => void) | undefined
+      this.stdout.write(wantHelp
+        ? USAGE_TEXT
+        : `dsh-tianshu-tui ${readOwnVersion(fileURLToPath(new URL('.', import.meta.url))) ?? 'unknown'}\n`)
+      if (exit !== undefined) { exit(0); return }
+      // 无 appExit（测试/裸装配）：保持 fail loud，由调用方 dispose 收尾。
+      throw new Error('[tui-runner] --help/--version requested but no appExit service provided')
+    }
     // bracketed paste：粘贴的多行文本被终端包裹为整段（行尾 CR 不再逐行触发
     // Enter 提交）；onPaste 处理器把整段插入输入行（超阈值折叠为标记）。
     this.stdout.write(ANSI.BRACKETED_PASTE_ON)
@@ -770,6 +802,10 @@ export class TuiApp {
       this.pendingUpdateNotice = null
     }
     this.flushLiveRender()
+    // A3：纯位置参数作为初始 prompt（`dsh --profile tui "修复这个 bug"`）。
+    if (initialPrompt !== '') {
+      this.handleSubmit(initialPrompt)
+    }
   }
 
   /**

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -4978,3 +4978,47 @@ describe('TuiApp 剪贴板图片与复制（opencode 接线移植）', () => {
     await app.dispose()
   })
 })
+
+describe('TuiApp cmdline 参数处理（A3）', () => {
+  it('--help 输出用法并经 appExit(0) 退出，不进入交互', async () => {
+    const ctx = makeCtx()
+    const agent = makeAgent('arg-help')
+    const handle = makeHandle(agent)
+    ctx.agents.create.mockResolvedValue(handle)
+    ctx.sessions.get.mockReturnValue(agent.session)
+    const exit = vi.fn()
+    ctx.reflect.get.mockImplementation((name: string) => {
+      if (name === 'cmdlineArgs') return { get: () => ['--help'] }
+      if (name === 'appExit') return exit
+      return undefined
+    })
+    const stdin = makeStdin()
+    const stdout = makeStdout()
+    const app = new TuiApp({ ctx, stdout, stdin })
+    await app.attach()
+    const written = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+    expect(written).toContain('dsh --profile tui')
+    expect(exit).toHaveBeenCalledWith(0)
+    // 未进入交互：没有创建会话/订阅（attach 提前返回）
+    expect(ctx.agents.create).not.toHaveBeenCalled()
+    await app.dispose()
+  })
+
+  it('纯位置参数作为初始 prompt 发送', async () => {
+    const ctx = makeCtx()
+    const agent = makeAgent('arg-prompt')
+    const handle = makeHandle(agent)
+    ctx.agents.create.mockResolvedValue(handle)
+    ctx.sessions.get.mockReturnValue(agent.session)
+    ctx.reflect.get.mockImplementation((name: string) => {
+      if (name === 'cmdlineArgs') return { get: () => ['修复这个', 'bug'] }
+      return undefined
+    })
+    const stdin = makeStdin()
+    const stdout = makeStdout()
+    const app = new TuiApp({ ctx, stdout, stdin })
+    await app.attach()
+    expect(firstCallText(agent.followup)).toBe('修复这个 bug')
+    await app.dispose()
+  })
+})

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -5021,4 +5021,52 @@ describe('TuiApp cmdline 参数处理（A3）', () => {
     expect(firstCallText(agent.followup)).toBe('修复这个 bug')
     await app.dispose()
   })
+
+  it('--version 输出版本并经 appExit(0) 退出', async () => {
+    const ctx = makeCtx()
+    const exit = vi.fn()
+    ctx.reflect.get.mockImplementation((name: string) => {
+      if (name === 'cmdlineArgs') return { get: () => ['--version'] }
+      if (name === 'appExit') return exit
+      return undefined
+    })
+    const stdout = makeStdout()
+    const app = new TuiApp({ ctx, stdout, stdin: makeStdin() })
+    await app.attach()
+    const written = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+    expect(written).toMatch(/dsh-tianshu-tui \d+\.\d+/)
+    expect(written).not.toContain('API Key')
+    expect(exit).toHaveBeenCalledWith(0)
+    expect(ctx.agents.create).not.toHaveBeenCalled()
+    await app.dispose()
+  })
+
+  it('无 appExit 时 --help 写出用法后 throw', async () => {
+    const ctx = makeCtx()
+    ctx.reflect.get.mockImplementation((name: string) => {
+      if (name === 'cmdlineArgs') return { get: () => ['-h'] }
+      return undefined
+    })
+    const stdout = makeStdout()
+    const app = new TuiApp({ ctx, stdout, stdin: makeStdin() })
+    await expect(app.attach()).rejects.toThrow('no appExit service provided')
+    const written = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+    expect(written).toContain('dsh --profile tui --help')
+    await app.dispose()
+  })
+
+  it('位置参数与其它 flag 并存时不发送 prompt', async () => {
+    const ctx = makeCtx()
+    const agent = makeAgent('arg-flags')
+    ctx.agents.create.mockResolvedValue(makeHandle(agent))
+    ctx.sessions.get.mockReturnValue(agent.session)
+    ctx.reflect.get.mockImplementation((name: string) => {
+      if (name === 'cmdlineArgs') return { get: () => ['修复这个', '--resume'] }
+      return undefined
+    })
+    const app = new TuiApp({ ctx, stdout: makeStdout(), stdin: makeStdin() })
+    await app.attach()
+    expect(agent.followup).not.toHaveBeenCalled()
+    await app.dispose()
+  })
 })

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -5004,6 +5004,24 @@ describe('TuiApp cmdline 参数处理（A3）', () => {
     await app.dispose()
   })
 
+  it('--help 读 host 注入的 ctx.cmdlineArgs（非 reflect 插件纤维）', async () => {
+    const ctx = makeCtx()
+    const exit = vi.fn()
+    Object.assign(ctx, {
+      cmdlineArgs: { get: () => ['--help'] },
+      appExit: exit,
+    })
+    const stdout = makeStdout()
+    const app = new TuiApp({ ctx, stdout, stdin: makeStdin() })
+    await app.attach()
+    const written = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+    expect(written).toContain('dsh --profile tui --help')
+    expect(written).not.toContain('API Key')
+    expect(exit).toHaveBeenCalledWith(0)
+    expect(ctx.agents.create).not.toHaveBeenCalled()
+    await app.dispose()
+  })
+
   it('纯位置参数作为初始 prompt 发送', async () => {
     const ctx = makeCtx()
     const agent = makeAgent('arg-prompt')


### PR DESCRIPTION
dsh 会把 launcher 参数转发给应用（dsh --profile tui <args>），但 TUI 完全忽略：
--help 直接进交互界面；位置参数被丢弃。

修复：
- --help/-h → 输出用法，经 appExit 退出
- --version/-v → 输出版本，经 appExit 退出
- 纯位置参数 → attach 完成后作为初始 prompt 发送
- 含其它 flag（如 --resume）保持原行为，避免组合语义冲突
- 无 appExit 时 throw（测试/裸装配 fail loud）
- 生产必须 inject cmdlineArgs/appExit：这两条是 launcher host provide，
  reflect.get 读不到，只 reflect 时 --help 仍进 TUI

测试：app.spec.ts --help 退出且不创建会话；位置参数发送；--version；
无 appExit 抛错；位置参数混 flag 不发送；host 注入属性路径。