### PR TITLE
feat: /session list 展示会话主题梗概并回填历史会话

### DIFF
--- a/SOURCE-MAP.md
+++ b/SOURCE-MAP.md
@@ -22,6 +22,7 @@
 | src/activity-store.ts | activity-store.ts | modified |
 | src/adapter/live.ts | — | new |
 | src/adapter/send.ts | — | new |
+| src/adapter/session-brief.ts | — | new（/session list 会话主题梗概：sidecar 缓存 + llm 辅助调用回填；无聊天记录显示「新对话」不调 API） |
 | src/adapter/sessions.ts | — | new |
 | src/adapter/tool-view.ts | — | new（presenter 桥：镜像 apiproxy viewFor 的 presentCall/presentResult 软降级消费） |
 | src/adapter/transcript.ts | — | new |

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ import { execFile, execSync, spawn, spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, extname, join, resolve, sep } from "node:path";
 import { randomUUID } from "node:crypto";
-import { mkdtemp, readFile, readdir, rm, stat, unlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { SessionId } from "@deepseek-ai/dsh-session";
 import { installModelSelection } from "@deepseek-ai/dsh-agent";
 import chalk from "chalk";
@@ -12,7 +12,7 @@ import { eastAsianWidthType } from "get-east-asian-width";
 import { monitorEventLoopDelay } from "node:perf_hooks";
 import { promisify } from "node:util";
 import { homedir, tmpdir } from "node:os";
-import { createUserMessage } from "@deepseek-ai/dsh-llm";
+import { BlockAssembler, createUserMessage } from "@deepseek-ai/dsh-llm";
 import { structuredPatch } from "diff";
 import { UserQuestionError } from "@deepseek-ai/dsh-user-questions";
 //#region lib/types/self-update.js
@@ -9707,6 +9707,26 @@ function getSession(ctx, id) {
 	return ctx.sessions.get(id);
 }
 /**
+* Load a session's event log for display. A live session's in-process log is
+* authoritative (it includes events not yet flushed); a persisted-only session
+* is loaded through `ctx.sessionPersistence.inspect` when available.
+* @param ctx - any context exposing `ctx.sessions` and optionally
+*   `ctx.sessionPersistence`.
+* @param id - the session whose log is requested.
+* @returns the immutable event log, or an empty array when the session is unknown.
+*/
+async function loadHistory(ctx, id) {
+	const live = ctx.sessions.get(id);
+	if (live !== void 0) return live.events;
+	const persistence = ctx.get("sessionPersistence");
+	if (persistence !== void 0) try {
+		return (await persistence.inspect(id)).events;
+	} catch {
+		return [];
+	}
+	return [];
+}
+/**
 * Flush every live session to durable storage — the teardown checkpoint.
 * Each flush dispatches the awaited `session/flush` durability barrier through
 * `ctx.sessions.flush`; persistence plugins drain their buffers there.
@@ -10812,14 +10832,14 @@ function truncate$2(s, max) {
 	return s.length > max ? s.slice(0, max - 1) + "…" : s;
 }
 /** unknown → 文本：string 原样；number/boolean 用 String；对象/null/undefined → ''（防 [object Object]）。 */
-function textOf(value) {
+function textOf$1(value) {
 	if (typeof value === "string") return value;
 	if (typeof value === "number" || typeof value === "boolean") return String(value);
 	return "";
 }
 /** 路径 basename（POSIX/Windows 分隔符都认）。 */
 function pathBasename(value) {
-	return textOf(value).replace(/^.*[/\\]/, "");
+	return textOf$1(value).replace(/^.*[/\\]/, "");
 }
 /**
 * 工具的主参数摘要（不含动词前缀）——供 `● Verb(arg)` 卡片标题使用。
@@ -10835,13 +10855,13 @@ function toolArgSummary(name, input) {
 		case "edit_file": return truncate$2(pathBasename(input.file_path ?? input.path), 45);
 		case "bash":
  /* v8 ignore next -- split('\n') 恒返回非空数组，[0] 恒存在；noUncheckedIndexedAccess 收窄防御 */
-		return truncate$2(textOf(input.command).split("\n")[0] ?? "", 55);
+		return truncate$2(textOf$1(input.command).split("\n")[0] ?? "", 55);
 		case "grep":
 		case "glob":
-		case "semantic_search": return truncate$2(textOf(input.pattern), 35);
-		case "delegate_task": return truncate$2(textOf(input.objective), 50);
+		case "semantic_search": return truncate$2(textOf$1(input.pattern), 35);
+		case "delegate_task": return truncate$2(textOf$1(input.objective), 50);
 		case "delegate_batch": return `${Array.isArray(input.tasks) ? input.tasks.length : "?"} tasks`;
-		case "web_fetch": return truncate$2(textOf(input.url), 50);
+		case "web_fetch": return truncate$2(textOf$1(input.url), 50);
 		default: return "";
 	}
 }
@@ -13181,6 +13201,319 @@ var WorkflowStatusLine = class {
 	}
 };
 //#endregion
+//#region lib/types/adapter/session-brief.js
+/**
+* Session brief — `/session list` 每行的会话主题梗概。
+*
+* 梗概是「研究的问题/主题本身」的任务标题式短语（如「评估某模型的识别准确率」
+* 「实现某插件的自动连接」），而不是「用户做了什么」的叙事。
+*
+* 职责与边界：
+* - 梗概是 TUI 私有展示层缓存：存放在 `$DSH_HOME/tui/session-briefs.json`
+*   （sidecar 文件，按 session id 索引），**不写回 session log、不发明事件类型**，
+*   符合 registry 的 dsh 纪律。
+* - 生成走既有 llm 服务的一次辅助调用（`purpose: 'session-title'`，DeepSeek
+*   适配器据此关闭 thinking，输出预算留给可见文本）。模型路由策略：
+*   deepseek 系 provider → 固定 `deepseek-v4-flash`（梗概是廉价辅助调用）；
+*   其它开发商 → 沿用用户当前默认模型（`agent-default-model.currentSelection`）。
+*   agent-default-model 服务缺失时回退到会话自身最新的 `request/header` 路由，
+*   再无则回退 harness 基线的 `deepseek-official/deepseek-v4-flash`。
+* - 历史会话（旧版本产生、无梗概）与新建会话统一按「缺则补」处理：首次
+*   `/session list` 时生成并落盘，之后读缓存，不再调 API。
+* - 没有任何聊天记录的会话不调 API：梗概直接展示「新对话」（状态，不落盘）。
+*
+* @module @deepseek-ai/dsh-tianshu-tui/adapter/session-brief
+*/
+/** 摘录输入的总字节预算（含 JSON 框架外的估算余量）。 */
+const MAX_INPUT_BYTES = 6e3;
+/** 端到端超时（与 session-title-llm 同档）。 */
+const BRIEF_TIMEOUT_MS = 6e4;
+/** 超时错误码（展示与诊断用）。 */
+const BRIEF_TIMEOUT_CODE = "SESSION_BRIEF_TIMEOUT";
+/** 无聊天记录的会话直接展示的占位梗概（状态而非内容，不落盘、不调 API）。 */
+const EMPTY_BRIEF = "新对话";
+/** deepseek 系 provider 的梗概固定模型。 */
+const BRIEF_MODEL = "deepseek-v4-flash";
+/** 无任何可用路由时的 harness 基线兜底。 */
+const DEFAULT_ROUTE = {
+	provider: "deepseek-official",
+	model: BRIEF_MODEL
+};
+/** 梗概 sidecar 文件在 dsh home 下的位置。 */
+const STORE_DIR = "tui";
+const STORE_FILE = "session-briefs.json";
+/**
+* 解析 dsh home：`$DSH_HOME`（非空白）优先，否则 `~/.dsh`。
+* 与 dsh-home-paths 的优先级一致（configured > $DSH_HOME > ~/.dsh）；
+* 「configured 路径」是宿主进程内的显式覆盖，插件侧不可见，按环境变量/
+* 默认值处理即可——sidecar 与 sessions 目录同根，两者解析一致。
+* @param env - 环境变量映射（测试可注入）。
+* @returns dsh home 绝对路径。
+*/
+function resolveDshHome(env = process.env) {
+	const explicit = env.DSH_HOME?.trim();
+	return explicit !== void 0 && explicit !== "" ? explicit : join(homedir(), ".dsh");
+}
+/**
+* 梗概 sidecar 文件路径。
+* @param home - dsh home；缺省由 {@link resolveDshHome} 解析。
+*/
+function briefsFilePath(home = resolveDshHome()) {
+	return join(home, STORE_DIR, STORE_FILE);
+}
+/** 读取 sidecar；缺失/损坏均容忍为空（梗概只是缓存，可重新生成）。 */
+async function readBriefs(file) {
+	try {
+		const raw = await readFile(file, "utf8");
+		const parsed = JSON.parse(raw);
+		if (parsed === null || typeof parsed !== "object") return {};
+		const briefs = parsed.briefs;
+		if (briefs === null || typeof briefs !== "object") return {};
+		const out = {};
+		for (const [id, brief] of Object.entries(briefs)) if (typeof brief === "string" && brief !== "") out[id] = brief;
+		return out;
+	} catch {
+		return {};
+	}
+}
+/** 原子写 sidecar：临时文件 + rename，避免中断留下半截 JSON。 */
+async function writeBriefs(file, briefs) {
+	await mkdir(dirname(file), { recursive: true });
+	const payload = {
+		version: 1,
+		briefs
+	};
+	const tmp = `${file}.${process.pid}.tmp`;
+	await writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
+	await rename(tmp, file);
+}
+/** 拼接消息中的全部文本块。 */
+function textOf(content) {
+	return content.filter((block) => block.type === "text").map((block) => block.text).join("\n").trim();
+}
+/** 按 UTF-8 字节上限截断（不劈开码点）。 */
+function truncateByBytes(text, max) {
+	if (max <= 0) return "";
+	if (Buffer.byteLength(text, "utf8") <= max) return text;
+	let out = "";
+	for (const ch of text) {
+		if (Buffer.byteLength(out + ch, "utf8") > max) break;
+		out += ch;
+	}
+	return out;
+}
+/**
+* 从会话事件摘录梗概输入：首条 + 末条真人用户消息，以及最后一条助手文本。
+* 合成注入（agent.inject 的 context 消息，source.kind !== 'user'）不入梗概；
+* 总字节数受 `maxBytes` 约束，超出的片段按顺序舍弃、最后一段截断。
+* @param events - 会话事件日志。
+* @param maxBytes - 输出摘录的总字节预算。
+* @returns 摘录轮次；无真人消息时为 []（调用方跳过生成）。
+*/
+function extractBriefTranscript(events, maxBytes = MAX_INPUT_BYTES) {
+	const userTexts = [];
+	const assistantTexts = [];
+	for (const event of events) if (event.type === "user/message") {
+		if (event.data.source?.kind !== "user") continue;
+		const text = textOf(event.data.content);
+		if (text !== "") userTexts.push(text);
+	} else if (event.type === "assistant/message") {
+		const text = textOf(event.data.message.content);
+		if (text !== "") assistantTexts.push(text);
+	}
+	const candidates = [];
+	const firstUser = userTexts[0];
+	const lastUser = userTexts[userTexts.length - 1];
+	if (firstUser !== void 0) candidates.push({
+		role: "user",
+		text: firstUser
+	});
+	if (userTexts.length > 1 && lastUser !== void 0) candidates.push({
+		role: "user",
+		text: lastUser
+	});
+	const lastAssistant = assistantTexts[assistantTexts.length - 1];
+	if (lastAssistant !== void 0) candidates.push({
+		role: "assistant",
+		text: lastAssistant
+	});
+	const turns = [];
+	let used = 0;
+	for (const candidate of candidates) {
+		if (used >= maxBytes) break;
+		const text = truncateByBytes(candidate.text, maxBytes - used);
+		if (text === "") continue;
+		turns.push({
+			role: candidate.role,
+			text
+		});
+		used += Buffer.byteLength(text, "utf8");
+	}
+	return turns;
+}
+/** 经 reflect.get 读取可选服务（Cordis 4：属性访问未注册服务会抛 without inject）。 */
+function readService(ctx, name) {
+	return ctx.reflect !== void 0 ? ctx.reflect.get(name, false) : ctx.get(name);
+}
+/**
+* 解析梗概调用的 provider/model 路由。
+* - 用户默认选择为 deepseek 系 provider → 固定 `deepseek-v4-flash`；
+* - 其它开发商 → 沿用默认选择本身（不对其它厂商强塞 deepseek 模型名）；
+* - agent-default-model 服务缺失 → 回退会话自身最新的 `request/header` 路由；
+* - 再无 → harness 基线 `deepseek-official/deepseek-v4-flash`。
+* @param ctx - 服务上下文。
+* @param events - 目标会话事件（路由回退用）。
+*/
+function resolveBriefRoute(ctx, events) {
+	const defaultModel = readService(ctx, "agentDefaultModel");
+	if (defaultModel !== void 0) try {
+		const selection = defaultModel.currentSelection();
+		if (selection.provider !== "" && selection.model !== "") return selection.provider.toLowerCase().includes("deepseek") ? {
+			provider: selection.provider,
+			model: BRIEF_MODEL
+		} : {
+			provider: selection.provider,
+			model: selection.model
+		};
+	} catch {}
+	for (let i = events.length - 1; i >= 0; i--) {
+		const event = events[i];
+		if (event?.type !== "request/header") continue;
+		const config = event.data.header.config;
+		if (config.provider === "" || config.model === "") continue;
+		return config.provider.toLowerCase().includes("deepseek") ? {
+			provider: config.provider,
+			model: BRIEF_MODEL
+		} : {
+			provider: config.provider,
+			model: config.model
+		};
+	}
+	return DEFAULT_ROUTE;
+}
+/**
+* 规范化模型输出：去终端控制符、折叠空白、剥离两侧引号/强调符，
+* 超出 {@link MAX_BRIEF_CHARS} 以 … 截断。空文本返回 ''。
+* @param raw - 模型原始输出。
+*/
+function normalizeBrief(raw) {
+	let text = raw.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "").replace(/\s+/g, " ").trim();
+	text = text.replace(/^["'“”‘’「」『』`*_-]+/, "").replace(/["'“”‘’「」『』`*_-]+$/, "");
+	text = text.trim();
+	if (text === "") return "";
+	const chars = Array.from(text);
+	if (chars.length > 120) return chars.slice(0, 119).join("") + "…";
+	return text;
+}
+/**
+* 一次辅助 LLM 调用：输入摘录 → 会话主题梗概（任务标题式短语）。
+* 失败（超时/模型错误/非文本输出）向上抛，由编排层记失败。
+*/
+async function generateBrief(ctx, id, route, turns) {
+	const llm = readService(ctx, "llm");
+	if (llm === void 0) throw new Error("llm 服务不可用，无法生成会话梗概");
+	const system = ["Summarize what this AI coding-assistant session is about as ONE concise topic phrase: the problem, subject, or goal the session works on, styled like a task title (e.g. \"评估某模型的识别准确率\", \"实现某插件的自动连接\", \"某版本发布与推送的关系\").", "Return only that topic phrase in plain text, in the language of the messages. No quotes, no Markdown, no prefixes, no terminal control codes. Do not narrate who asked or what was done."].join("\n");
+	const framed = `Summarize the research topic of this session from the transcript excerpt (JSON array of user turns and the final assistant turn):\n${JSON.stringify(turns)}`;
+	const messages = [createUserMessage({
+		content: [{
+			type: "text",
+			text: framed
+		}],
+		source: {
+			kind: "plugin",
+			plugin: "dsh-tianshu-tui"
+		}
+	})];
+	const signal = AbortSignal.any([AbortSignal.timeout(BRIEF_TIMEOUT_MS)]);
+	const options = {
+		provider: route.provider,
+		model: route.model,
+		messages,
+		system,
+		maxTokens: 128,
+		sessionId: id,
+		purpose: "session-title",
+		signal
+	};
+	const assembler = new BlockAssembler();
+	try {
+		for await (const chunk of llm.stream(options)) {
+			signal.throwIfAborted();
+			assembler.push(chunk);
+		}
+	} catch (error) {
+		if (signal.aborted) {
+			const timeout = /* @__PURE__ */ new Error("会话梗概生成超时");
+			timeout.code = BRIEF_TIMEOUT_CODE;
+			throw timeout;
+		}
+		throw error;
+	}
+	const finish = assembler.finish;
+	if (finish.kind === "error" || finish.kind === "aborted") {
+		const failure = /* @__PURE__ */ new Error(`会话梗概生成失败: ${finish.failure.message}`);
+		failure.code = finish.failure.code;
+		throw failure;
+	}
+	if (finish.kind === "max-tokens") throw new Error("会话梗概生成失败: 输出达到 token 上限");
+	if (finish.kind === "tool-calls") throw new Error("会话梗概生成失败: 模型意外请求了工具");
+	/* v8 ignore next -- finish.kind 恒为 'stop'；merge-extensible 词汇的未知值防御 */
+	if (finish.kind !== "stop") throw new Error(`会话梗概生成失败: 未知结束原因 ${String(finish.kind)}`);
+	const brief = normalizeBrief(assembler.blocks().filter((block) => block.type === "text").map((block) => block.text).join(" "));
+	if (brief === "") throw new Error("会话梗概生成失败: 模型未产出文本");
+	return brief;
+}
+/**
+* 保证 `rows` 中每个会话都有梗概：缓存命中直接复用；缺失则生成并落盘
+* （历史会话回填与新会话首次展示统一走这条路径）；无任何聊天记录的会话
+* 直接标 {@link EMPTY_BRIEF}（不调 API、不落盘、不回显进度）。串行执行，
+* 回显顺序与行序一致；单个失败跳过并记 `onFailed`，下次 `/session list` 重试。
+* @param ctx - 服务上下文（llm / agentDefaultModel / sessions / sessionPersistence）。
+* @param rows - 待展示的会话行（`listSessions` 产出，新→旧）。
+* @param hooks - 进度钩子（可选）。
+* @param storeFile - sidecar 文件路径（测试注入；缺省用 dsh home 下的固定位置）。
+* @returns session id → 梗概（成功生成/缓存/「新对话」项；生成失败项不在其中）。
+*/
+async function ensureSessionBriefs(ctx, rows, hooks = {}, storeFile = briefsFilePath()) {
+	const store = await readBriefs(storeFile);
+	const result = /* @__PURE__ */ new Map();
+	for (const row of rows) {
+		const cached = store[row.id];
+		if (cached !== void 0) result.set(row.id, cached);
+	}
+	const prepared = [];
+	const emptyIds = [];
+	for (const row of rows) {
+		if (store[row.id] !== void 0) continue;
+		const events = await loadHistory(ctx, row.id);
+		const turns = extractBriefTranscript(events);
+		if (turns.length > 0) prepared.push({
+			row,
+			events,
+			turns
+		});
+		else emptyIds.push(row.id);
+	}
+	for (const id of emptyIds) result.set(id, EMPTY_BRIEF);
+	for (let i = 0; i < prepared.length; i++) {
+		const entry = prepared[i];
+		/* v8 ignore next -- push 后的下标恒有值；noUncheckedIndexedAccess 收窄防御 */
+		if (entry === void 0) continue;
+		hooks.onPending?.(entry.row.id, i, prepared.length);
+		try {
+			const route = resolveBriefRoute(ctx, entry.events);
+			const brief = await generateBrief(ctx, entry.row.id, route, entry.turns);
+			const fresh = await readBriefs(storeFile);
+			fresh[entry.row.id] = brief;
+			await writeBriefs(storeFile, fresh);
+			result.set(entry.row.id, brief);
+		} catch (error) {
+			hooks.onFailed?.(entry.row.id, error);
+		}
+	}
+	return result;
+}
+//#endregion
 //#region lib/types/format/doctor-report.js
 /**
 * 收集终端诊断报告。
@@ -13465,7 +13798,19 @@ function createBuiltinCommands(deps) {
 						echo("（当前无会话）");
 						return;
 					}
-					for (const row of rows) echo(`${row.id} · ${new Date(row.createdAt).toISOString()}`);
+					const briefs = await ensureSessionBriefs(ctx, rows, {
+						onPending: (id, completed, total) => {
+							echo(`正在生成会话梗概 (${completed + 1}/${total}): ${id}`);
+						},
+						onFailed: (id) => {
+							echo(`⚠ 会话梗概生成失败: ${id}（可稍后再次 /session list 重试）`);
+						}
+					});
+					for (const row of rows) {
+						const brief = briefs.get(row.id);
+						const time = new Date(row.createdAt).toISOString();
+						echo(brief === void 0 ? `${row.id} · ${time}` : `${row.id} · ${brief} · ${time}`);
+					}
 					return;
 				}
 				if (sub === "switch") {

--- a/lib/types/adapter/session-brief.d.ts
+++ b/lib/types/adapter/session-brief.d.ts
@@ -1,0 +1,103 @@
+/**
+ * Session brief — `/session list` 每行的会话主题梗概。
+ *
+ * 梗概是「研究的问题/主题本身」的任务标题式短语（如「评估某模型的识别准确率」
+ * 「实现某插件的自动连接」），而不是「用户做了什么」的叙事。
+ *
+ * 职责与边界：
+ * - 梗概是 TUI 私有展示层缓存：存放在 `$DSH_HOME/tui/session-briefs.json`
+ *   （sidecar 文件，按 session id 索引），**不写回 session log、不发明事件类型**，
+ *   符合 registry 的 dsh 纪律。
+ * - 生成走既有 llm 服务的一次辅助调用（`purpose: 'session-title'`，DeepSeek
+ *   适配器据此关闭 thinking，输出预算留给可见文本）。模型路由策略：
+ *   deepseek 系 provider → 固定 `deepseek-v4-flash`（梗概是廉价辅助调用）；
+ *   其它开发商 → 沿用用户当前默认模型（`agent-default-model.currentSelection`）。
+ *   agent-default-model 服务缺失时回退到会话自身最新的 `request/header` 路由，
+ *   再无则回退 harness 基线的 `deepseek-official/deepseek-v4-flash`。
+ * - 历史会话（旧版本产生、无梗概）与新建会话统一按「缺则补」处理：首次
+ *   `/session list` 时生成并落盘，之后读缓存，不再调 API。
+ * - 没有任何聊天记录的会话不调 API：梗概直接展示「新对话」（状态，不落盘）。
+ *
+ * @module @deepseek-ai/dsh-tianshu-tui/adapter/session-brief
+ */
+import type { Context } from '@deepseek-ai/cordis';
+import type { SessionId, SessionEvent } from '@deepseek-ai/dsh-session';
+import { type SessionSummary } from './sessions.js';
+/** 梗概提示词输入摘录的一轮：真人用户消息或最后一条助手消息。 */
+export interface BriefTranscriptTurn {
+    readonly role: 'user' | 'assistant';
+    readonly text: string;
+}
+/** 摘录输入的总字节预算（含 JSON 框架外的估算余量）。 */
+export declare const MAX_INPUT_BYTES = 6000;
+/** 辅助调用输出 token 上限（一句话梗概足够）。 */
+export declare const MAX_OUTPUT_TOKENS = 128;
+/** 端到端超时（与 session-title-llm 同档）。 */
+export declare const BRIEF_TIMEOUT_MS = 60000;
+/** 超时错误码（展示与诊断用）。 */
+export declare const BRIEF_TIMEOUT_CODE = "SESSION_BRIEF_TIMEOUT";
+/** 梗概文本长度上限（字符，超出以 … 截断）。 */
+export declare const MAX_BRIEF_CHARS = 120;
+/** 无聊天记录的会话直接展示的占位梗概（状态而非内容，不落盘、不调 API）。 */
+export declare const EMPTY_BRIEF = "\u65B0\u5BF9\u8BDD";
+/**
+ * 解析 dsh home：`$DSH_HOME`（非空白）优先，否则 `~/.dsh`。
+ * 与 dsh-home-paths 的优先级一致（configured > $DSH_HOME > ~/.dsh）；
+ * 「configured 路径」是宿主进程内的显式覆盖，插件侧不可见，按环境变量/
+ * 默认值处理即可——sidecar 与 sessions 目录同根，两者解析一致。
+ * @param env - 环境变量映射（测试可注入）。
+ * @returns dsh home 绝对路径。
+ */
+export declare function resolveDshHome(env?: NodeJS.ProcessEnv): string;
+/**
+ * 梗概 sidecar 文件路径。
+ * @param home - dsh home；缺省由 {@link resolveDshHome} 解析。
+ */
+export declare function briefsFilePath(home?: string): string;
+/**
+ * 从会话事件摘录梗概输入：首条 + 末条真人用户消息，以及最后一条助手文本。
+ * 合成注入（agent.inject 的 context 消息，source.kind !== 'user'）不入梗概；
+ * 总字节数受 `maxBytes` 约束，超出的片段按顺序舍弃、最后一段截断。
+ * @param events - 会话事件日志。
+ * @param maxBytes - 输出摘录的总字节预算。
+ * @returns 摘录轮次；无真人消息时为 []（调用方跳过生成）。
+ */
+export declare function extractBriefTranscript(events: readonly SessionEvent[], maxBytes?: number): BriefTranscriptTurn[];
+/**
+ * 解析梗概调用的 provider/model 路由。
+ * - 用户默认选择为 deepseek 系 provider → 固定 `deepseek-v4-flash`；
+ * - 其它开发商 → 沿用默认选择本身（不对其它厂商强塞 deepseek 模型名）；
+ * - agent-default-model 服务缺失 → 回退会话自身最新的 `request/header` 路由；
+ * - 再无 → harness 基线 `deepseek-official/deepseek-v4-flash`。
+ * @param ctx - 服务上下文。
+ * @param events - 目标会话事件（路由回退用）。
+ */
+export declare function resolveBriefRoute(ctx: Context, events: readonly SessionEvent[]): {
+    provider: string;
+    model: string;
+};
+/**
+ * 规范化模型输出：去终端控制符、折叠空白、剥离两侧引号/强调符，
+ * 超出 {@link MAX_BRIEF_CHARS} 以 … 截断。空文本返回 ''。
+ * @param raw - 模型原始输出。
+ */
+export declare function normalizeBrief(raw: string): string;
+/** 批量生成进度钩子。 */
+export interface BriefGenerationHooks {
+    /** 每个待生成会话开始前回调；completed 为已处理数，total 为待生成总数。 */
+    onPending?(id: SessionId, completed: number, total: number): void;
+    /** 单个会话生成失败时回调（不中断整体）。 */
+    onFailed?(id: SessionId, error: unknown): void;
+}
+/**
+ * 保证 `rows` 中每个会话都有梗概：缓存命中直接复用；缺失则生成并落盘
+ * （历史会话回填与新会话首次展示统一走这条路径）；无任何聊天记录的会话
+ * 直接标 {@link EMPTY_BRIEF}（不调 API、不落盘、不回显进度）。串行执行，
+ * 回显顺序与行序一致；单个失败跳过并记 `onFailed`，下次 `/session list` 重试。
+ * @param ctx - 服务上下文（llm / agentDefaultModel / sessions / sessionPersistence）。
+ * @param rows - 待展示的会话行（`listSessions` 产出，新→旧）。
+ * @param hooks - 进度钩子（可选）。
+ * @param storeFile - sidecar 文件路径（测试注入；缺省用 dsh home 下的固定位置）。
+ * @returns session id → 梗概（成功生成/缓存/「新对话」项；生成失败项不在其中）。
+ */
+export declare function ensureSessionBriefs(ctx: Context, rows: readonly SessionSummary[], hooks?: BriefGenerationHooks, storeFile?: string): Promise<Map<string, string>>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@huiliyi37/dsh-tianshu-tui",
-  "version": "0.1.2-rc.6",
+  "version": "0.1.2-rc.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@huiliyi37/dsh-tianshu-tui",
-      "version": "0.1.2-rc.6",
+      "version": "0.1.2-rc.7",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^6.0.0",

--- a/src/adapter/session-brief.ts
+++ b/src/adapter/session-brief.ts
@@ -1,0 +1,389 @@
+/**
+ * Session brief — `/session list` 每行的会话主题梗概。
+ *
+ * 梗概是「研究的问题/主题本身」的任务标题式短语（如「评估某模型的识别准确率」
+ * 「实现某插件的自动连接」），而不是「用户做了什么」的叙事。
+ *
+ * 职责与边界：
+ * - 梗概是 TUI 私有展示层缓存：存放在 `$DSH_HOME/tui/session-briefs.json`
+ *   （sidecar 文件，按 session id 索引），**不写回 session log、不发明事件类型**，
+ *   符合 registry 的 dsh 纪律。
+ * - 生成走既有 llm 服务的一次辅助调用（`purpose: 'session-title'`，DeepSeek
+ *   适配器据此关闭 thinking，输出预算留给可见文本）。模型路由策略：
+ *   deepseek 系 provider → 固定 `deepseek-v4-flash`（梗概是廉价辅助调用）；
+ *   其它开发商 → 沿用用户当前默认模型（`agent-default-model.currentSelection`）。
+ *   agent-default-model 服务缺失时回退到会话自身最新的 `request/header` 路由，
+ *   再无则回退 harness 基线的 `deepseek-official/deepseek-v4-flash`。
+ * - 历史会话（旧版本产生、无梗概）与新建会话统一按「缺则补」处理：首次
+ *   `/session list` 时生成并落盘，之后读缓存，不再调 API。
+ * - 没有任何聊天记录的会话不调 API：梗概直接展示「新对话」（状态，不落盘）。
+ *
+ * @module @deepseek-ai/dsh-tianshu-tui/adapter/session-brief
+ */
+
+import type { Context } from '@deepseek-ai/cordis'
+import type { SessionId, SessionEvent } from '@deepseek-ai/dsh-session'
+import type { ContentBlock, GenerateOptions, StreamChunk } from '@deepseek-ai/dsh-llm'
+import { BlockAssembler, createUserMessage } from '@deepseek-ai/dsh-llm'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { loadHistory, type SessionSummary } from './sessions.js'
+
+/** agent-default-model 的最小读面（与 registry.ts 的 ModelFacet 同构）。 */
+interface DefaultModelFacet {
+  currentSelection(): { provider: string; model: string; reasoningEffort?: string }
+}
+
+/** llm 服务的最小调用面（只消费 stream；类型由 dsh-llm 提供）。 */
+interface LlmFacet {
+  stream(options: GenerateOptions): AsyncIterable<StreamChunk>
+}
+
+/** 梗概提示词输入摘录的一轮：真人用户消息或最后一条助手消息。 */
+export interface BriefTranscriptTurn {
+  readonly role: 'user' | 'assistant'
+  readonly text: string
+}
+
+/** 摘录输入的总字节预算（含 JSON 框架外的估算余量）。 */
+export const MAX_INPUT_BYTES = 6000
+/** 辅助调用输出 token 上限（一句话梗概足够）。 */
+export const MAX_OUTPUT_TOKENS = 128
+/** 端到端超时（与 session-title-llm 同档）。 */
+export const BRIEF_TIMEOUT_MS = 60_000
+/** 超时错误码（展示与诊断用）。 */
+export const BRIEF_TIMEOUT_CODE = 'SESSION_BRIEF_TIMEOUT'
+/** 梗概文本长度上限（字符，超出以 … 截断）。 */
+export const MAX_BRIEF_CHARS = 120
+/** 无聊天记录的会话直接展示的占位梗概（状态而非内容，不落盘、不调 API）。 */
+export const EMPTY_BRIEF = '新对话'
+/** deepseek 系 provider 的梗概固定模型。 */
+const BRIEF_MODEL = 'deepseek-v4-flash'
+/** 无任何可用路由时的 harness 基线兜底。 */
+const DEFAULT_ROUTE = { provider: 'deepseek-official', model: BRIEF_MODEL }
+/** 梗概 sidecar 文件在 dsh home 下的位置。 */
+const STORE_DIR = 'tui'
+const STORE_FILE = 'session-briefs.json'
+
+/**
+ * 解析 dsh home：`$DSH_HOME`（非空白）优先，否则 `~/.dsh`。
+ * 与 dsh-home-paths 的优先级一致（configured > $DSH_HOME > ~/.dsh）；
+ * 「configured 路径」是宿主进程内的显式覆盖，插件侧不可见，按环境变量/
+ * 默认值处理即可——sidecar 与 sessions 目录同根，两者解析一致。
+ * @param env - 环境变量映射（测试可注入）。
+ * @returns dsh home 绝对路径。
+ */
+export function resolveDshHome(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = env.DSH_HOME?.trim()
+  return explicit !== undefined && explicit !== '' ? explicit : join(homedir(), '.dsh')
+}
+
+/**
+ * 梗概 sidecar 文件路径。
+ * @param home - dsh home；缺省由 {@link resolveDshHome} 解析。
+ */
+export function briefsFilePath(home: string = resolveDshHome()): string {
+  return join(home, STORE_DIR, STORE_FILE)
+}
+
+/** sidecar 文件内容（带版本号的信封，未来可演进）。 */
+interface BriefStoreFile {
+  readonly version: 1
+  readonly briefs: Record<string, string>
+}
+
+/** 读取 sidecar；缺失/损坏均容忍为空（梗概只是缓存，可重新生成）。 */
+async function readBriefs(file: string): Promise<Record<string, string>> {
+  try {
+    const raw = await readFile(file, 'utf8')
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed === null || typeof parsed !== 'object') return {}
+    const briefs = (parsed as { briefs?: unknown }).briefs
+    if (briefs === null || typeof briefs !== 'object') return {}
+    const out: Record<string, string> = {}
+    for (const [id, brief] of Object.entries(briefs as Record<string, unknown>)) {
+      if (typeof brief === 'string' && brief !== '') out[id] = brief
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+/** 原子写 sidecar：临时文件 + rename，避免中断留下半截 JSON。 */
+async function writeBriefs(file: string, briefs: Record<string, string>): Promise<void> {
+  await mkdir(dirname(file), { recursive: true })
+  const payload: BriefStoreFile = { version: 1, briefs }
+  const tmp = `${file}.${process.pid}.tmp`
+  await writeFile(tmp, JSON.stringify(payload, null, 2), 'utf8')
+  await rename(tmp, file)
+}
+
+/** 拼接消息中的全部文本块。 */
+function textOf(content: readonly ContentBlock[]): string {
+  return content
+    .filter(block => block.type === 'text')
+    .map(block => block.text)
+    .join('\n')
+    .trim()
+}
+
+/** 按 UTF-8 字节上限截断（不劈开码点）。 */
+function truncateByBytes(text: string, max: number): string {
+  if (max <= 0) return ''
+  if (Buffer.byteLength(text, 'utf8') <= max) return text
+  let out = ''
+  for (const ch of text) {
+    if (Buffer.byteLength(out + ch, 'utf8') > max) break
+    out += ch
+  }
+  return out
+}
+
+/**
+ * 从会话事件摘录梗概输入：首条 + 末条真人用户消息，以及最后一条助手文本。
+ * 合成注入（agent.inject 的 context 消息，source.kind !== 'user'）不入梗概；
+ * 总字节数受 `maxBytes` 约束，超出的片段按顺序舍弃、最后一段截断。
+ * @param events - 会话事件日志。
+ * @param maxBytes - 输出摘录的总字节预算。
+ * @returns 摘录轮次；无真人消息时为 []（调用方跳过生成）。
+ */
+export function extractBriefTranscript(
+  events: readonly SessionEvent[],
+  maxBytes: number = MAX_INPUT_BYTES,
+): BriefTranscriptTurn[] {
+  const userTexts: string[] = []
+  const assistantTexts: string[] = []
+  for (const event of events) {
+    if (event.type === 'user/message') {
+      // 只取真人提示；?. 防御旧日志缺 source 的退化数据。
+      if (event.data.source?.kind !== 'user') continue
+      const text = textOf(event.data.content)
+      if (text !== '') userTexts.push(text)
+    } else if (event.type === 'assistant/message') {
+      const text = textOf(event.data.message.content)
+      if (text !== '') assistantTexts.push(text)
+    }
+  }
+  const candidates: BriefTranscriptTurn[] = []
+  const firstUser = userTexts[0]
+  const lastUser = userTexts[userTexts.length - 1]
+  if (firstUser !== undefined) candidates.push({ role: 'user', text: firstUser })
+  if (userTexts.length > 1 && lastUser !== undefined) candidates.push({ role: 'user', text: lastUser })
+  const lastAssistant = assistantTexts[assistantTexts.length - 1]
+  if (lastAssistant !== undefined) candidates.push({ role: 'assistant', text: lastAssistant })
+  const turns: BriefTranscriptTurn[] = []
+  let used = 0
+  for (const candidate of candidates) {
+    if (used >= maxBytes) break
+    const text = truncateByBytes(candidate.text, maxBytes - used)
+    if (text === '') continue
+    turns.push({ role: candidate.role, text })
+    used += Buffer.byteLength(text, 'utf8')
+  }
+  return turns
+}
+
+/** 经 reflect.get 读取可选服务（Cordis 4：属性访问未注册服务会抛 without inject）。 */
+function readService<T>(ctx: Context, name: string): T | undefined {
+  const value = ctx.reflect !== undefined
+    ? ctx.reflect.get(name, false)
+    : ctx.get(name)
+  return value as T | undefined
+}
+
+/**
+ * 解析梗概调用的 provider/model 路由。
+ * - 用户默认选择为 deepseek 系 provider → 固定 `deepseek-v4-flash`；
+ * - 其它开发商 → 沿用默认选择本身（不对其它厂商强塞 deepseek 模型名）；
+ * - agent-default-model 服务缺失 → 回退会话自身最新的 `request/header` 路由；
+ * - 再无 → harness 基线 `deepseek-official/deepseek-v4-flash`。
+ * @param ctx - 服务上下文。
+ * @param events - 目标会话事件（路由回退用）。
+ */
+export function resolveBriefRoute(
+  ctx: Context,
+  events: readonly SessionEvent[],
+): { provider: string; model: string } {
+  const defaultModel = readService<DefaultModelFacet>(ctx, 'agentDefaultModel')
+  if (defaultModel !== undefined) {
+    try {
+      const selection = defaultModel.currentSelection()
+      if (selection.provider !== '' && selection.model !== '') {
+        return selection.provider.toLowerCase().includes('deepseek')
+          ? { provider: selection.provider, model: BRIEF_MODEL }
+          : { provider: selection.provider, model: selection.model }
+      }
+    } catch {
+      // 服务异常时按未配置处理，走事件路由回退。
+    }
+  }
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i]
+    if (event?.type !== 'request/header') continue
+    const config = event.data.header.config
+    if (config.provider === '' || config.model === '') continue
+    return config.provider.toLowerCase().includes('deepseek')
+      ? { provider: config.provider, model: BRIEF_MODEL }
+      : { provider: config.provider, model: config.model }
+  }
+  return DEFAULT_ROUTE
+}
+
+/**
+ * 规范化模型输出：去终端控制符、折叠空白、剥离两侧引号/强调符，
+ * 超出 {@link MAX_BRIEF_CHARS} 以 … 截断。空文本返回 ''。
+ * @param raw - 模型原始输出。
+ */
+export function normalizeBrief(raw: string): string {
+  let text = raw
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  text = text.replace(/^["'“”‘’「」『』`*_-]+/, '').replace(/["'“”‘’「」『』`*_-]+$/, '')
+  text = text.trim()
+  if (text === '') return ''
+  const chars = Array.from(text)
+  if (chars.length > MAX_BRIEF_CHARS) return chars.slice(0, MAX_BRIEF_CHARS - 1).join('') + '…'
+  return text
+}
+
+/**
+ * 一次辅助 LLM 调用：输入摘录 → 会话主题梗概（任务标题式短语）。
+ * 失败（超时/模型错误/非文本输出）向上抛，由编排层记失败。
+ */
+async function generateBrief(
+  ctx: Context,
+  id: SessionId,
+  route: { provider: string; model: string },
+  turns: readonly BriefTranscriptTurn[],
+): Promise<string> {
+  const llm = readService<LlmFacet>(ctx, 'llm')
+  if (llm === undefined) throw new Error('llm 服务不可用，无法生成会话梗概')
+  // 梗概 = 会话研究的问题/主题本身（任务标题式短语），不是「用户做了什么」的
+  // 叙事——示例风格：「评估某模型的识别准确率」「实现某插件的自动连接」「某库
+  // 升级与发布的关系」。动词开头（实现/修复/评估…）可接受，动作的施事者不可出现。
+  const system = [
+    'Summarize what this AI coding-assistant session is about as ONE concise topic phrase: the problem, subject, or goal the session works on, styled like a task title (e.g. "评估某模型的识别准确率", "实现某插件的自动连接", "某版本发布与推送的关系").',
+    'Return only that topic phrase in plain text, in the language of the messages. No quotes, no Markdown, no prefixes, no terminal control codes. Do not narrate who asked or what was done.',
+  ].join('\n')
+  const framed = `Summarize the research topic of this session from the transcript excerpt (JSON array of user turns and the final assistant turn):\n${JSON.stringify(turns)}`
+  const messages = [createUserMessage({
+    content: [{ type: 'text', text: framed }],
+    source: { kind: 'plugin', plugin: 'dsh-tianshu-tui' },
+  })]
+  // 调用方（/session list 命令）无取消路径，只挂超时。
+  const signal = AbortSignal.any([AbortSignal.timeout(BRIEF_TIMEOUT_MS)])
+  const options: GenerateOptions = {
+    provider: route.provider,
+    model: route.model,
+    messages,
+    system,
+    maxTokens: MAX_OUTPUT_TOKENS,
+    sessionId: id,
+    // 辅助调用的既有 purpose 词汇：DeepSeek 适配器据此关闭 thinking，
+    // 把输出预算留给主题梗概。
+    purpose: 'session-title',
+    signal,
+  }
+  const assembler = new BlockAssembler()
+  try {
+    for await (const chunk of llm.stream(options)) {
+      signal.throwIfAborted()
+      assembler.push(chunk)
+    }
+  } catch (error) {
+    if (signal.aborted) {
+      const timeout = new Error('会话梗概生成超时') as Error & { code?: string }
+      timeout.code = BRIEF_TIMEOUT_CODE
+      throw timeout
+    }
+    throw error
+  }
+  const finish = assembler.finish
+  if (finish.kind === 'error' || finish.kind === 'aborted') {
+    const failure = new Error(`会话梗概生成失败: ${finish.failure.message}`) as Error & { code?: string }
+    failure.code = finish.failure.code
+    throw failure
+  }
+  if (finish.kind === 'max-tokens') throw new Error('会话梗概生成失败: 输出达到 token 上限')
+  if (finish.kind === 'tool-calls') throw new Error('会话梗概生成失败: 模型意外请求了工具')
+  /* v8 ignore next -- finish.kind 恒为 'stop'；merge-extensible 词汇的未知值防御 */
+  if ((finish.kind as string) !== 'stop') {
+    throw new Error(`会话梗概生成失败: 未知结束原因 ${String(finish.kind)}`)
+  }
+  const brief = normalizeBrief(
+    assembler.blocks().filter(block => block.type === 'text').map(block => block.text).join(' '),
+  )
+  if (brief === '') throw new Error('会话梗概生成失败: 模型未产出文本')
+  return brief
+}
+
+/** 批量生成进度钩子。 */
+export interface BriefGenerationHooks {
+  /** 每个待生成会话开始前回调；completed 为已处理数，total 为待生成总数。 */
+  onPending?(id: SessionId, completed: number, total: number): void
+  /** 单个会话生成失败时回调（不中断整体）。 */
+  onFailed?(id: SessionId, error: unknown): void
+}
+
+/**
+ * 保证 `rows` 中每个会话都有梗概：缓存命中直接复用；缺失则生成并落盘
+ * （历史会话回填与新会话首次展示统一走这条路径）；无任何聊天记录的会话
+ * 直接标 {@link EMPTY_BRIEF}（不调 API、不落盘、不回显进度）。串行执行，
+ * 回显顺序与行序一致；单个失败跳过并记 `onFailed`，下次 `/session list` 重试。
+ * @param ctx - 服务上下文（llm / agentDefaultModel / sessions / sessionPersistence）。
+ * @param rows - 待展示的会话行（`listSessions` 产出，新→旧）。
+ * @param hooks - 进度钩子（可选）。
+ * @param storeFile - sidecar 文件路径（测试注入；缺省用 dsh home 下的固定位置）。
+ * @returns session id → 梗概（成功生成/缓存/「新对话」项；生成失败项不在其中）。
+ */
+export async function ensureSessionBriefs(
+  ctx: Context,
+  rows: readonly SessionSummary[],
+  hooks: BriefGenerationHooks = {},
+  storeFile: string = briefsFilePath(),
+): Promise<Map<string, string>> {
+  const store = await readBriefs(storeFile)
+  const result = new Map<string, string>()
+  for (const row of rows) {
+    const cached = store[row.id]
+    if (cached !== undefined) result.set(row.id, cached)
+  }
+  // 先为缺失项加载事件日志并分拣：有真人消息的进入生成队列；
+  // 无任何聊天记录的直接标「新对话」——不调 API、不回显进度、也不落盘
+  // （它是状态不是内容；落盘会让会话后续产生记录后仍读到过期的「新对话」）。
+  const prepared: Array<{
+    row: SessionSummary
+    events: readonly SessionEvent[]
+    turns: BriefTranscriptTurn[]
+  }> = []
+  const emptyIds: SessionId[] = []
+  for (const row of rows) {
+    if (store[row.id] !== undefined) continue
+    const events = await loadHistory(ctx, row.id)
+    const turns = extractBriefTranscript(events)
+    if (turns.length > 0) prepared.push({ row, events, turns })
+    else emptyIds.push(row.id)
+  }
+  for (const id of emptyIds) result.set(id, EMPTY_BRIEF)
+  for (let i = 0; i < prepared.length; i++) {
+    const entry = prepared[i]
+    /* v8 ignore next -- push 后的下标恒有值；noUncheckedIndexedAccess 收窄防御 */
+    if (entry === undefined) continue
+    hooks.onPending?.(entry.row.id, i, prepared.length)
+    try {
+      const route = resolveBriefRoute(ctx, entry.events)
+      const brief = await generateBrief(ctx, entry.row.id, route, entry.turns)
+      // 逐会话读-改-写：中断/失败时已完成的会话仍保留。
+      const fresh = await readBriefs(storeFile)
+      fresh[entry.row.id] = brief
+      await writeBriefs(storeFile, fresh)
+      result.set(entry.row.id, brief)
+    } catch (error) {
+      hooks.onFailed?.(entry.row.id, error)
+    }
+  }
+  return result
+}

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -19,6 +19,7 @@ import type { Context } from '@deepseek-ai/cordis'
 import type { SessionId } from '@deepseek-ai/dsh-session'
 import { getActiveThemeName, setTheme, THEME_NAMES } from '../theme.js'
 import { listSessions } from '../adapter/sessions.js'
+import { ensureSessionBriefs } from '../adapter/session-brief.js'
 import { collectDoctorReport, getDoctorFixGuidance } from '../format/doctor-report.js'
 
 /**
@@ -303,8 +304,24 @@ export function createBuiltinCommands(deps: BuiltinCommandDeps): SlashCommand[] 
             echo('（当前无会话）')
             return
           }
+          // 每行在 session id 旁展示会话主题梗概（研究问题/主题的任务标题式
+          // 短语）。梗概是 TUI 私有 sidecar 缓存（$DSH_HOME/tui/session-briefs.json），
+          // 不写 session log；缺失的会话（含旧版本产生的历史会话）在此按需
+          // 生成并落盘回填；无聊天记录的会话直接显示「新对话」。
+          const briefs = await ensureSessionBriefs(ctx, rows, {
+            onPending: (id, completed, total) => {
+              echo(`正在生成会话梗概 (${completed + 1}/${total}): ${id}`)
+            },
+            onFailed: (id) => {
+              echo(`⚠ 会话梗概生成失败: ${id}（可稍后再次 /session list 重试）`)
+            },
+          })
           for (const row of rows) {
-            echo(`${row.id} · ${new Date(row.createdAt).toISOString()}`)
+            const brief = briefs.get(row.id)
+            const time = new Date(row.createdAt).toISOString()
+            echo(brief === undefined
+              ? `${row.id} · ${time}`
+              : `${row.id} · ${brief} · ${time}`)
           }
           return
         }

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -1777,9 +1777,11 @@ describe('TuiApp Phase 6.1 slash 命令系统', () => {
     const app = new TuiApp({ ctx, stdout, stdin: makeStdin() })
     await app.newSession()
     app.handleSubmit('/session list')
-    await new Promise(resolve => setImmediate(resolve))
-
-    expect(stdout.write.mock.calls.map(c => `${c[0]}`).join('')).toContain('slash-sess')
+    // 梗概回填使该命令成为真实异步路径（sidecar 读盘 + 逐会话梗概编排），
+    // 单次 setImmediate 不再够用，waitFor 轮询（与文件内其它异步命令测试同款）。
+    await vi.waitFor(() => {
+      expect(stdout.write.mock.calls.map(c => `${c[0]}`).join('')).toContain('slash-sess')
+    }, { timeout: 2_000, interval: 20 })
     await app.dispose()
   })
 

--- a/tests/commands.spec.ts
+++ b/tests/commands.spec.ts
@@ -10,7 +10,11 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Context } from '@deepseek-ai/cordis'
-import type { SessionId } from '@deepseek-ai/dsh-session'
+import type { SessionEvent, SessionId } from '@deepseek-ai/dsh-session'
+import type { StreamChunk } from '@deepseek-ai/dsh-llm'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   BUILTIN_COMMAND_NAMES,
   SlashCommandRegistry,
@@ -20,7 +24,7 @@ import {
 import { getActiveThemeName, setTheme } from '../src/theme.js'
 
 /** 最小 ctx 替身：/session list 需要的 sessions.list + get('sessionPersistence')。 */
-function makeCtx(overrides: Partial<Record<'sessions' | 'agents' | 'compact' | 'agentDefaultModel' | 'goals' | 'tasks', unknown>> = {}): Context {
+function makeCtx(overrides: Partial<Record<'sessions' | 'agents' | 'compact' | 'agentDefaultModel' | 'goals' | 'tasks' | 'llm', unknown>> = {}): Context {
   const ctx = {
     sessions: {
       list: vi.fn(() => []),
@@ -275,6 +279,139 @@ describe('内置命令 — /session', () => {
     await cmd.run(args)
     expect(deps.newSession).not.toHaveBeenCalled()
     expect(echo).toHaveBeenCalledWith(expect.stringContaining('/session new|list'))
+  })
+})
+
+describe('内置命令 — /session list 梗概（sidecar 缓存 + LLM 回填）', () => {
+  const homeEnv = 'DSH_HOME'
+
+  /** 以临时 dsh home 跑一段测试，结束后还原环境并清理。 */
+  async function withTempHome(fn: (home: string) => Promise<void>): Promise<void> {
+    const home = await mkdtemp(join(tmpdir(), 'dsh-tui-cmd-'))
+    const prev = process.env[homeEnv]
+    process.env[homeEnv] = home
+    try {
+      await fn(home)
+    } finally {
+      if (prev === undefined) delete process.env[homeEnv]
+      else process.env[homeEnv] = prev
+      await rm(home, { recursive: true, force: true })
+    }
+  }
+
+  function briefEvents(question: string, answer: string): SessionEvent[] {
+    return [
+      {
+        seq: 1,
+        time: 1001,
+        type: 'user/message',
+        data: { content: [{ type: 'text', text: question }], source: { kind: 'user' } },
+      },
+      {
+        seq: 2,
+        time: 1002,
+        type: 'assistant/message',
+        data: { turn: 1, step: 1, message: { content: [{ type: 'text', text: answer }] } },
+      },
+    ] as unknown as SessionEvent[]
+  }
+
+  it('list 在 id 旁展示已缓存的会话梗概', async () => {
+    await withTempHome(async (home) => {
+      const { cmd } = commandByName('session')
+      const sid = 'session-brief-1' as SessionId
+      await mkdir(join(home, 'tui'), { recursive: true })
+      await writeFile(
+        join(home, 'tui', 'session-briefs.json'),
+        JSON.stringify({ version: 1, briefs: { 'session-brief-1': '一句话梗概示例' } }),
+      )
+      const ctx = makeCtx({
+        sessions: {
+          list: vi.fn(() => [{ id: sid, header: { id: sid, version: 0, createdAt: 1 } }]),
+          get: vi.fn(() => undefined),
+        },
+      })
+      const { args, echo } = makeArgs({ text: 'list', ctx })
+      await cmd.run(args)
+      expect(echo).toHaveBeenCalledWith(expect.stringContaining('session-brief-1 · 一句话梗概示例 ·'))
+    })
+  })
+
+  it('list 无梗概时经 llm 生成回填（deepseek 默认选择替换为 flash）并落盘', async () => {
+    await withTempHome(async (home) => {
+      const { cmd } = commandByName('session')
+      const sid = 'session-brief-2' as SessionId
+      const live = { id: sid, events: briefEvents('写个脚本', '完成') }
+      const stream = vi.fn<(options: { provider: string; model: string }) => AsyncIterable<StreamChunk>>(async function* () {
+        yield { type: 'block-start', index: 0, blockType: 'text' } as StreamChunk
+        yield { type: 'text-delta', index: 0, text: '经 API 生成的一句话梗概' } as StreamChunk
+        yield { type: 'block-end', index: 0, block: { type: 'text', text: '经 API 生成的一句话梗概' } } as StreamChunk
+        yield { type: 'finish', reason: { kind: 'stop' } } as StreamChunk
+      })
+      const ctx = makeCtx({
+        llm: { stream },
+        agentDefaultModel: { currentSelection: () => ({ provider: 'deepseek-official', model: 'deepseek-v4-pro' }) },
+        sessions: {
+          list: vi.fn(() => [{ id: sid, header: { id: sid, version: 0, createdAt: 1 }, events: live.events }]),
+          get: vi.fn(() => live),
+        },
+      })
+      const { args, echo } = makeArgs({ text: 'list', ctx })
+      await cmd.run(args)
+      expect(echo).toHaveBeenCalledWith(expect.stringContaining('正在生成会话梗概 (1/1): session-brief-2'))
+      expect(echo).toHaveBeenCalledWith(expect.stringContaining('session-brief-2 · 经 API 生成的一句话梗概 ·'))
+      const options = stream.mock.calls[0][0]
+      expect(options).toMatchObject({ provider: 'deepseek-official', model: 'deepseek-v4-flash' })
+      const saved = JSON.parse(await readFile(join(home, 'tui', 'session-briefs.json'), 'utf8')) as { briefs: Record<string, string> }
+      expect(saved.briefs[sid]).toBe('经 API 生成的一句话梗概')
+    })
+  })
+
+  it('list 梗概生成失败时回显警告且仍列出会话行', async () => {
+    await withTempHome(async (home) => {
+      const { cmd } = commandByName('session')
+      const sid = 'session-brief-3' as SessionId
+      const live = { id: sid, events: briefEvents('问题', '回答') }
+      const ctx = makeCtx({
+        llm: {
+          stream: vi.fn(async function* () {
+            yield {
+              type: 'finish',
+              reason: { kind: 'error', failure: { message: 'boom', code: 'BOOM' } },
+            } as StreamChunk
+          }),
+        },
+        sessions: {
+          list: vi.fn(() => [{ id: sid, header: { id: sid, version: 0, createdAt: 1 }, events: live.events }]),
+          get: vi.fn(() => live),
+        },
+      })
+      const { args, echo } = makeArgs({ text: 'list', ctx })
+      await cmd.run(args)
+      expect(echo).toHaveBeenCalledWith(expect.stringContaining('⚠ 会话梗概生成失败: session-brief-3'))
+      expect(echo).toHaveBeenCalledWith(expect.stringContaining(`session-brief-3 · ${new Date(1).toISOString()}`))
+    })
+  })
+
+  it('list 无聊天记录的会话直接展示「新对话」，不调 llm', async () => {
+    await withTempHome(async (home) => {
+      const { cmd } = commandByName('session')
+      const sid = 'session-brief-4' as SessionId
+      const stream = vi.fn<(options: unknown) => AsyncIterable<StreamChunk>>(async function* () {
+        throw new Error('不应被调用')
+      })
+      const ctx = makeCtx({
+        llm: { stream },
+        sessions: {
+          list: vi.fn(() => [{ id: sid, header: { id: sid, version: 0, createdAt: 1 }, events: [] }]),
+          get: vi.fn(() => ({ id: sid, events: [] })),
+        },
+      })
+      const { args, echo } = makeArgs({ text: 'list', ctx })
+      await cmd.run(args)
+      expect(echo).toHaveBeenCalledWith(expect.stringContaining('session-brief-4 · 新对话 ·'))
+      expect(stream).not.toHaveBeenCalled()
+    })
   })
 })
 

--- a/tests/session-brief.spec.ts
+++ b/tests/session-brief.spec.ts
@@ -1,0 +1,359 @@
+/**
+ * session-brief 适配层测试：梗概 sidecar 存储、输入摘录、路由解析、
+ * LLM 生成与 /session list 回填编排。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Context } from '@deepseek-ai/cordis'
+import type { SessionEvent, SessionId } from '@deepseek-ai/dsh-session'
+import type { StreamChunk } from '@deepseek-ai/dsh-llm'
+import {
+  EMPTY_BRIEF,
+  MAX_BRIEF_CHARS,
+  briefsFilePath,
+  ensureSessionBriefs,
+  extractBriefTranscript,
+  normalizeBrief,
+  resolveBriefRoute,
+  resolveDshHome,
+} from '../src/adapter/session-brief.js'
+import type { SessionSummary } from '../src/adapter/sessions.js'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+
+let tempDir: string
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'dsh-tui-brief-'))
+})
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+const storeFile = (): string => join(tempDir, 'tui', 'session-briefs.json')
+const sid = (n: string): SessionId => `session-brief-${n}` as SessionId
+
+function row(id: SessionId, createdAt = 1): SessionSummary {
+  return { id, version: 0, createdAt, cwd: undefined, parentSession: undefined }
+}
+
+function userEvent(seq: number, text: string): SessionEvent {
+  return {
+    seq,
+    time: 1000 + seq,
+    type: 'user/message',
+    data: { content: [{ type: 'text', text }], source: { kind: 'user' } },
+  } as unknown as SessionEvent
+}
+
+function pluginUserEvent(seq: number, text: string): SessionEvent {
+  return {
+    seq,
+    time: 1000 + seq,
+    type: 'user/message',
+    data: { content: [{ type: 'text', text }], source: { kind: 'plugin', plugin: 'test' } },
+  } as unknown as SessionEvent
+}
+
+function assistantEvent(seq: number, text: string): SessionEvent {
+  return {
+    seq,
+    time: 1000 + seq,
+    type: 'assistant/message',
+    data: { turn: 1, step: 1, message: { content: [{ type: 'text', text }] } },
+  } as unknown as SessionEvent
+}
+
+function requestHeaderEvent(seq: number, provider: string, model: string): SessionEvent {
+  return {
+    seq,
+    time: 1000 + seq,
+    type: 'request/header',
+    data: { header: { config: { provider, model } }, reason: 'initial' },
+  } as unknown as SessionEvent
+}
+
+/** 组成一段完整文本响应的 chunk 流。 */
+function textChunks(text: string): StreamChunk[] {
+  return [
+    { type: 'block-start', index: 0, blockType: 'text' },
+    { type: 'text-delta', index: 0, text },
+    { type: 'block-end', index: 0, block: { type: 'text', text } },
+    { type: 'finish', reason: { kind: 'stop' } },
+  ]
+}
+
+/** 最小 ctx 替身：reflect.get/get 返回 overrides；sessions 走内存表。 */
+function makeCtx(
+  overrides: Record<string, unknown> = {},
+  sessions: Array<{ id: SessionId; events: SessionEvent[] }> = [],
+): Context {
+  const byId = new Map(sessions.map(s => [s.id, s]))
+  const ctx = {
+    reflect: { get: vi.fn((name: string) => overrides[name]) },
+    get: vi.fn((name: string) => overrides[name]),
+    sessions: {
+      list: vi.fn(() => sessions),
+      get: vi.fn((id: SessionId) => byId.get(id)),
+    },
+  } as unknown as Context
+  return ctx
+}
+
+/** 可断言的 llm 替身：stream 记录 options 并按 chunksProvider 产出。 */
+function makeLlm(chunksProvider: () => StreamChunk[]): {
+  stream: ReturnType<typeof vi.fn<(options: unknown) => AsyncIterable<StreamChunk>>>
+} {
+  const stream = vi.fn<(options: unknown) => AsyncIterable<StreamChunk>>(async function* () {
+    yield* chunksProvider()
+  })
+  return { stream }
+}
+
+describe('resolveDshHome / briefsFilePath', () => {
+  it('DSH_HOME 优先，空白视为未设置，缺省 ~/.dsh', () => {
+    expect(resolveDshHome({})).toBe(join(homedir(), '.dsh'))
+    expect(resolveDshHome({ DSH_HOME: '  ' })).toBe(join(homedir(), '.dsh'))
+    expect(resolveDshHome({ DSH_HOME: '/tmp/dsh-x' })).toBe('/tmp/dsh-x')
+  })
+
+  it('briefsFilePath 位于 <home>/tui/session-briefs.json', () => {
+    expect(briefsFilePath('/tmp/dsh-x')).toBe('/tmp/dsh-x/tui/session-briefs.json')
+  })
+})
+
+describe('normalizeBrief', () => {
+  it('剥离控制符并折叠空白', () => {
+    expect(normalizeBrief(' 一句话\n\r 梗概 \t内容 ')).toBe('一句话 梗概 内容')
+  })
+
+  it('剥离两侧引号与 Markdown 强调符', () => {
+    expect(normalizeBrief('"**一句话梗概**"')).toBe('一句话梗概')
+    expect(normalizeBrief('「一句话梗概」')).toBe('一句话梗概')
+  })
+
+  it(`超出 ${MAX_BRIEF_CHARS} 字符以 … 截断`, () => {
+    const long = '梗'.repeat(MAX_BRIEF_CHARS + 30)
+    const out = normalizeBrief(long)
+    expect(Array.from(out).length).toBe(MAX_BRIEF_CHARS)
+    expect(out.endsWith('…')).toBe(true)
+  })
+
+  it('空白/引号残留为空串', () => {
+    expect(normalizeBrief('""')).toBe('')
+    expect(normalizeBrief('   ')).toBe('')
+  })
+})
+
+describe('extractBriefTranscript', () => {
+  it('取首条+末条真人用户消息与最后一条助手消息', () => {
+    const events = [
+      userEvent(1, '第一条问题'),
+      assistantEvent(2, '第一次回答'),
+      userEvent(3, '第二条问题'),
+      assistantEvent(4, '最终回答'),
+    ]
+    const turns = extractBriefTranscript(events)
+    expect(turns).toEqual([
+      { role: 'user', text: '第一条问题' },
+      { role: 'user', text: '第二条问题' },
+      { role: 'assistant', text: '最终回答' },
+    ])
+  })
+
+  it('跳过合成注入消息与空文本', () => {
+    const events = [
+      pluginUserEvent(1, '注入的上下文'),
+      userEvent(2, '真实问题'),
+      assistantEvent(3, '回答'),
+    ]
+    const turns = extractBriefTranscript(events)
+    expect(turns.map(t => t.text)).toEqual(['真实问题', '回答'])
+  })
+
+  it('超过字节预算时按顺序舍弃并截断末段', () => {
+    const events = [
+      userEvent(1, 'x'.repeat(100)),
+      userEvent(2, 'y'.repeat(100)),
+      assistantEvent(3, 'z'.repeat(100)),
+    ]
+    const turns = extractBriefTranscript(events, 150)
+    // 100x + 50y（截断），z 段被预算挤出。
+    expect(turns).toEqual([
+      { role: 'user', text: 'x'.repeat(100) },
+      { role: 'user', text: 'y'.repeat(50) },
+    ])
+  })
+
+  it('无真人消息返回空数组', () => {
+    expect(extractBriefTranscript([pluginUserEvent(1, '仅注入')])).toEqual([])
+    expect(extractBriefTranscript([])).toEqual([])
+  })
+})
+
+describe('resolveBriefRoute', () => {
+  it('deepseek 系默认选择固定为 deepseek-v4-flash', () => {
+    const ctx = makeCtx({
+      agentDefaultModel: { currentSelection: () => ({ provider: 'deepseek-official', model: 'deepseek-v4-pro' }) },
+    })
+    expect(resolveBriefRoute(ctx, [])).toEqual({ provider: 'deepseek-official', model: 'deepseek-v4-flash' })
+  })
+
+  it('其它开发商沿用默认选择本身', () => {
+    const ctx = makeCtx({
+      agentDefaultModel: { currentSelection: () => ({ provider: 'openai', model: 'gpt-5' }) },
+    })
+    expect(resolveBriefRoute(ctx, [])).toEqual({ provider: 'openai', model: 'gpt-5' })
+  })
+
+  it('服务缺失时回退会话最新 request/header 路由（deepseek 同样替换 flash）', () => {
+    const ctx = makeCtx()
+    const events = [
+      requestHeaderEvent(1, 'deepseek-official', 'deepseek-v4-pro'),
+    ]
+    expect(resolveBriefRoute(ctx, events)).toEqual({ provider: 'deepseek-official', model: 'deepseek-v4-flash' })
+    const other = [requestHeaderEvent(1, 'openai', 'gpt-5')]
+    expect(resolveBriefRoute(ctx, other)).toEqual({ provider: 'openai', model: 'gpt-5' })
+  })
+
+  it('currentSelection 抛错时走事件路由回退', () => {
+    const ctx = makeCtx({
+      agentDefaultModel: { currentSelection: () => { throw new Error('broken') } },
+    })
+    const events = [requestHeaderEvent(1, 'openai', 'gpt-5')]
+    expect(resolveBriefRoute(ctx, events)).toEqual({ provider: 'openai', model: 'gpt-5' })
+  })
+
+  it('无任何路由信息时回退 harness 基线 flash', () => {
+    expect(resolveBriefRoute(makeCtx(), [])).toEqual({ provider: 'deepseek-official', model: 'deepseek-v4-flash' })
+  })
+})
+
+describe('ensureSessionBriefs', () => {
+  it('缓存命中直接复用，不调 llm', async () => {
+    await mkdir(join(tempDir, 'tui'), { recursive: true })
+    await writeFile(storeFile(), JSON.stringify({ version: 1, briefs: { [sid('a')]: '已缓存梗概' } }))
+    const { stream } = makeLlm(() => { throw new Error('不应被调用') })
+    const ctx = makeCtx({ llm: { stream } })
+    const map = await ensureSessionBriefs(ctx, [row(sid('a'))], {}, storeFile())
+    expect(map.get(sid('a'))).toBe('已缓存梗概')
+    expect(stream).not.toHaveBeenCalled()
+  })
+
+  it('缺失梗概时生成并落盘；deepseek 默认选择替换为 flash', async () => {
+    const { stream } = makeLlm(() => textChunks('生成的一句话梗概'))
+    const ctx = makeCtx(
+      { llm: { stream }, agentDefaultModel: { currentSelection: () => ({ provider: 'deepseek-official', model: 'deepseek-v4-pro' }) } },
+      [{ id: sid('a'), events: [userEvent(1, '帮我写个测试'), assistantEvent(2, '已写好')] }],
+    )
+    const onPending = vi.fn()
+    const onFailed = vi.fn()
+    const map = await ensureSessionBriefs(ctx, [row(sid('a'))], { onPending, onFailed }, storeFile())
+    expect(map.get(sid('a'))).toBe('生成的一句话梗概')
+    expect(onPending).toHaveBeenCalledWith(sid('a'), 0, 1)
+    expect(onFailed).not.toHaveBeenCalled()
+    // 路由与输出上限符合约定
+    const options = stream.mock.calls[0][0] as { provider: string; model: string; maxTokens: number; system: string }
+    expect(options.provider).toBe('deepseek-official')
+    expect(options.model).toBe('deepseek-v4-flash')
+    expect(options.maxTokens).toBe(128)
+    // 梗概 = 研究主题短语（任务标题式），不是「用户做了什么」的叙事。
+    expect(options.system).toContain('topic phrase')
+    expect(options.system).toContain('Do not narrate who asked')
+    // 已落盘：再次调用（llm 换成抛错替身）仍读缓存
+    const cached = JSON.parse(await readFile(storeFile(), 'utf8')) as { briefs: Record<string, string> }
+    expect(cached.briefs[sid('a')]).toBe('生成的一句话梗概')
+    const { stream: boom } = makeLlm(() => { throw new Error('不应被调用') })
+    const again = await ensureSessionBriefs(makeCtx({ llm: { stream: boom } }), [row(sid('a'))], {}, storeFile())
+    expect(again.get(sid('a'))).toBe('生成的一句话梗概')
+    expect(boom).not.toHaveBeenCalled()
+  })
+
+  it('其它开发商的默认选择原样透传', async () => {
+    const { stream } = makeLlm(() => textChunks('openai 生成的一句话梗概'))
+    const ctx = makeCtx(
+      { llm: { stream }, agentDefaultModel: { currentSelection: () => ({ provider: 'openai', model: 'gpt-5' }) } },
+      [{ id: sid('a'), events: [userEvent(1, '问题')] }],
+    )
+    const map = await ensureSessionBriefs(ctx, [row(sid('a'))], {}, storeFile())
+    expect(map.get(sid('a'))).toBe('openai 生成的一句话梗概')
+    const options = stream.mock.calls[0][0] as { provider: string; model: string }
+    expect(options).toMatchObject({ provider: 'openai', model: 'gpt-5' })
+  })
+
+  it('生成失败记 onFailed、不落盘、不中断其它会话', async () => {
+    const { stream } = makeLlm(() => [
+      { type: 'finish', reason: { kind: 'error', failure: { message: 'boom', code: 'BOOM' } } },
+    ])
+    const okLlm = makeLlm(() => textChunks('另一个会话的梗概'))
+    const okId = sid('ok')
+    const badId = sid('bad')
+    const ctx = makeCtx(
+      {
+        llm: {
+          stream: vi.fn((options: { sessionId: SessionId }) => {
+            return options.sessionId === badId
+              ? stream(options)
+              : okLlm.stream(options)
+          }),
+        },
+      },
+      [
+        { id: badId, events: [userEvent(1, '问题 A')] },
+        { id: okId, events: [userEvent(1, '问题 B')] },
+      ],
+    )
+    const onPending = vi.fn()
+    const onFailed = vi.fn()
+    const map = await ensureSessionBriefs(ctx, [row(badId), row(okId)], { onPending, onFailed }, storeFile())
+    expect(map.get(okId)).toBe('另一个会话的梗概')
+    expect(map.has(badId)).toBe(false)
+    expect(onFailed).toHaveBeenCalledTimes(1)
+    expect(onFailed.mock.calls[0][0]).toBe(badId)
+    expect(onPending).toHaveBeenCalledTimes(2)
+    // 落盘只含成功项
+    const cached = JSON.parse(await readFile(storeFile(), 'utf8')) as { briefs: Record<string, string> }
+    expect(cached.briefs).toEqual({ [okId]: '另一个会话的梗概' })
+  })
+
+  it('无聊天记录的会话直接标「新对话」：不调 llm、不回显进度、不落盘', async () => {
+    const { stream } = makeLlm(() => { throw new Error('不应被调用') })
+    const ctx = makeCtx(
+      { llm: { stream } },
+      [{ id: sid('a'), events: [pluginUserEvent(1, '仅注入上下文')] }],
+    )
+    const onPending = vi.fn()
+    const map = await ensureSessionBriefs(ctx, [row(sid('a'))], { onPending }, storeFile())
+    expect(map.get(sid('a'))).toBe(EMPTY_BRIEF)
+    expect(onPending).not.toHaveBeenCalled()
+    expect(stream).not.toHaveBeenCalled()
+    // 「新对话」是状态不是内容，不写入 sidecar（文件都不产生）。
+    await expect(readFile(storeFile(), 'utf8')).rejects.toThrow()
+  })
+
+  it('「新对话」不缓存：会话之后产生记录，下次经 API 生成真实梗概', async () => {
+    const firstLlm = makeLlm(() => { throw new Error('不应被调用') })
+    const emptyCtx = makeCtx({ llm: { stream: firstLlm.stream } }, [{ id: sid('a'), events: [] }])
+    const first = await ensureSessionBriefs(emptyCtx, [row(sid('a'))], {}, storeFile())
+    expect(first.get(sid('a'))).toBe(EMPTY_BRIEF)
+    // 会话产生聊天记录后再次列举：不再读到「新对话」，而是走 API 生成。
+    const { stream } = makeLlm(() => textChunks('后来生成的梗概'))
+    const grownCtx = makeCtx(
+      { llm: { stream } },
+      [{ id: sid('a'), events: [userEvent(1, '后来提出的问题')] }],
+    )
+    const second = await ensureSessionBriefs(grownCtx, [row(sid('a'))], {}, storeFile())
+    expect(second.get(sid('a'))).toBe('后来生成的梗概')
+    expect(stream).toHaveBeenCalledTimes(1)
+  })
+
+  it('llm 服务缺失时记失败并返回空映射', async () => {
+    const ctx = makeCtx({}, [{ id: sid('a'), events: [userEvent(1, '问题')] }])
+    const onFailed = vi.fn()
+    const map = await ensureSessionBriefs(ctx, [row(sid('a'))], { onFailed }, storeFile())
+    expect(map.size).toBe(0)
+    expect(onFailed).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## 动机

#25 提出为 `/session list` 增加「session 摘要」栏目。issue 未获回复，故按开源惯例直接实现并提交 PR 供评审；如与作者设计不符，愿意按意见修订。

## 改动

- 新增 `src/adapter/session-brief.ts`：
  - 梗概存储：TUI 私有 sidecar `$DSH_HOME/tui/session-briefs.json`（按 session id 索引，原子写、损坏容忍）；
  - 输入摘录：首条 + 末条真人用户消息与末条助手消息，字节预算截断；
  - 模型路由解析与一次辅助 LLM 调用生成。
- `/session list` 每行改为 `id · 梗概 · 时间`：
  - 缺失梗概的会话（含旧版本产生的历史会话）串行生成回填并落盘，有进度回显；单条失败回显警告且不中断整体；
  - 无聊天记录的会话直接显示「新对话」，不调 API（不落盘——它是状态而非内容）。
- 模型路由三级回退：deepseek 系 provider 固定 `deepseek-v4-flash`；其它厂商沿用当前默认模型；无 `agent-default-model` 服务时回退会话自身 `request/header` 路由，再无则回退 harness 基线。

## 设计取舍（请评审）

1. **梗概存 sidecar 文件而非 session log / storage 服务**：遵守本仓「命令不写回 session log、不发明事件类型」纪律；`dsh-storage` 不在 base profile 装配面。梗概是快照——会话产生新内容后不自动重生成（刷新方式：删除 sidecar 中对应条目后重新 `/session list`）。
2. **辅助调用复用 `purpose: 'session-title'`**：既有词汇，DeepSeek 适配器据此关闭 thinking，节省输出预算。
3. **梗概风格为「研究主题」任务标题式短语**（如「评估某模型的识别准确率」「实现某插件的自动连接」），而非「用户做了什么」的叙事。

## 测试

- 新增 `tests/session-brief.spec.ts`（23 例），`tests/commands.spec.ts`、`tests/app.spec.ts` 回归同步；本地全量 `npm test` 1690 + 32 通过，`npm run typecheck`、`npm run build` 干净。
- 已在真实 dsh profile 验证（本机 link 安装）：21 个历史会话中 7 个生成梗概、14 个显示「新对话」，第二次 `/session list` 纯走缓存、零 API 调用。

## 其它

- 未改版本号、未动发布流程；`package-lock.json` 仅同步版本号 0.1.2-rc.7 以通过 CI 的 `npm ci`（原 lockfile 落后于 package.json）。
- 新代码为原创，`SOURCE-MAP.md` 已登记 `new` 条目；未加 DCO 签名（仓库未发现要求）。

Closes #25
