### PR TITLE
fix(self-update): 消除 DEP0190 弃用警告（Windows 自更新 spawn）

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,7 +109,6 @@ function installNpmVersion(latest, profileDir, timeoutMs = 6e4) {
 		const command = isWin ? process.env.ComSpec ?? "cmd.exe" : "pnpm";
 		const args = isWin ? [
 			"/d",
-			"/s",
 			"/c",
 			"pnpm",
 			"add",

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,10 +105,20 @@ async function fetchNpmLatest(packageName = TUI_PACKAGE, timeoutMs = 3e3) {
 }
 function installNpmVersion(latest, profileDir, timeoutMs = 6e4) {
 	return new Promise((resolve, reject) => {
-		const child = spawn("pnpm", ["add", `${TUI_PACKAGE}@${latest}`], {
+		const isWin = process.platform === "win32";
+		const command = isWin ? process.env.ComSpec ?? "cmd.exe" : "pnpm";
+		const args = isWin ? [
+			"/d",
+			"/s",
+			"/c",
+			"pnpm",
+			"add",
+			`${TUI_PACKAGE}@${latest}`
+		] : ["add", `${TUI_PACKAGE}@${latest}`];
+		const child = spawn(command, args, {
 			cwd: profileDir,
 			stdio: "ignore",
-			shell: process.platform === "win32"
+			windowsHide: true
 		});
 		const timer = setTimeout(() => {
 			child.kill();

--- a/src/self-update.ts
+++ b/src/self-update.ts
@@ -130,10 +130,21 @@ export async function fetchNpmLatest(packageName: string = TUI_PACKAGE, timeoutM
 
 export function installNpmVersion(latest: string, profileDir: string, timeoutMs = 60_000): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn('pnpm', ['add', `${TUI_PACKAGE}@${latest}`], {
+    // Windows 上 pnpm 是 pnpm.cmd，spawn 直接执行会 EINVAL（.cmd 不能
+    // 不经 shell 启动），传 'pnpm' 又会 ENOENT（无扩展名不在 PATH）。
+    // 经 cmd.exe /d /s /c 显式派发：shell:false 时 args 作为 argv 传给
+    // cmd.exe，不触发 Node DEP0190 弃用警告（shell:true + args 数组组合
+    // 会把警告经 stderr 渲染进 TUI 输入框区域）。version 来自 npm registry
+    // 的 semver 字符串（无空格/引号/重定向等元字符），拼接安全。
+    const isWin = process.platform === 'win32'
+    const command = isWin ? (process.env.ComSpec ?? 'cmd.exe') : 'pnpm'
+    const args = isWin
+      ? ['/d', '/s', '/c', 'pnpm', 'add', `${TUI_PACKAGE}@${latest}`]
+      : ['add', `${TUI_PACKAGE}@${latest}`]
+    const child = spawn(command, args, {
       cwd: profileDir,
       stdio: 'ignore',
-      shell: process.platform === 'win32',
+      windowsHide: true,
     })
     const timer = setTimeout(() => {
       child.kill()

--- a/src/self-update.ts
+++ b/src/self-update.ts
@@ -132,14 +132,15 @@ export function installNpmVersion(latest: string, profileDir: string, timeoutMs 
   return new Promise((resolve, reject) => {
     // Windows 上 pnpm 是 pnpm.cmd，spawn 直接执行会 EINVAL（.cmd 不能
     // 不经 shell 启动），传 'pnpm' 又会 ENOENT（无扩展名不在 PATH）。
-    // 经 cmd.exe /d /s /c 显式派发：shell:false 时 args 作为 argv 传给
+    // 经 cmd.exe /d /c 显式派发：shell:false 时 args 作为 argv 传给
     // cmd.exe，不触发 Node DEP0190 弃用警告（shell:true + args 数组组合
     // 会把警告经 stderr 渲染进 TUI 输入框区域）。version 来自 npm registry
-    // 的 semver 字符串（无空格/引号/重定向等元字符），拼接安全。
+    // 的 semver 字符串，字符集受限（无空格/引号/&|<> 等元字符），实际注入
+    // 面低；cmd /c 对参数数组按 argv 传递，不拼 shell 字符串。
     const isWin = process.platform === 'win32'
     const command = isWin ? (process.env.ComSpec ?? 'cmd.exe') : 'pnpm'
     const args = isWin
-      ? ['/d', '/s', '/c', 'pnpm', 'add', `${TUI_PACKAGE}@${latest}`]
+      ? ['/d', '/c', 'pnpm', 'add', `${TUI_PACKAGE}@${latest}`]
       : ['add', `${TUI_PACKAGE}@${latest}`]
     const child = spawn(command, args, {
       cwd: profileDir,

--- a/tests/install-npm-version.spec.ts
+++ b/tests/install-npm-version.spec.ts
@@ -56,7 +56,7 @@ describe('installNpmVersion', () => {
     expect(spawnMock).toHaveBeenCalledTimes(1)
     const [command, args, options] = spawnMock.mock.calls[0]!
     expect(command).toBe(process.env.ComSpec ?? 'cmd.exe')
-    expect(args).toEqual(['/d', '/s', '/c', 'pnpm', 'add', '@huiliyi37/dsh-tianshu-tui@0.1.2-rc.7'])
+    expect(args).toEqual(['/d', '/c', 'pnpm', 'add', '@huiliyi37/dsh-tianshu-tui@0.1.2-rc.7'])
     expect(options).not.toHaveProperty('shell', true)
   })
 

--- a/tests/install-npm-version.spec.ts
+++ b/tests/install-npm-version.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * install-npm-version.spec.ts — installNpmVersion 的 spawn 调用契约。
+ *
+ * 回归目标（DEP0190）：Windows 下不得再以 `shell: true` + args 数组调用
+ * child_process.spawn——该组合触发 Node 弃用警告，警告经 stderr 被 TUI
+ * 渲染进输入框区域（用户报告的上屏乱码根因）。修复后 spawn 应改为
+ * `cmd.exe /d /s /c` 显式派发（shell: false，args 作为 argv 传递）。
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}))
+
+// 动态 import：确保 child_process mock 生效后再加载被测模块
+import { installNpmVersion } from '../src/self-update.js'
+
+function stubChild() {
+  return {
+    kill: vi.fn(),
+    on: vi.fn(),
+    stdout: { on: vi.fn() },
+    stdin: { write: vi.fn(), end: vi.fn() },
+  }
+}
+
+describe('installNpmVersion', () => {
+  const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+  beforeEach(() => {
+    spawnMock.mockReset()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { ...origPlatform })
+  })
+
+  function platform(win32: boolean): void {
+    Object.defineProperty(process, 'platform', { value: win32 ? 'win32' : 'linux', configurable: true })
+  }
+
+  it('win32：经 cmd.exe /d /s /c 显式派发，shell 不为 true（DEP0190 回归）', async () => {
+    platform(true)
+    spawnMock.mockReturnValue(stubChild())
+    const child = stubChild()
+    spawnMock.mockReturnValue(child)
+
+    const p = installNpmVersion('0.1.2-rc.7', '/tmp/profile')
+    // 触发 exit 回调
+    const exitHandler = child.on.mock.calls.find(([ev]) => ev === 'exit')?.[1] as (code: number | null) => void
+    exitHandler(0)
+    await p
+
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    const [command, args, options] = spawnMock.mock.calls[0]!
+    expect(command).toBe(process.env.ComSpec ?? 'cmd.exe')
+    expect(args).toEqual(['/d', '/s', '/c', 'pnpm', 'add', '@huiliyi37/dsh-tianshu-tui@0.1.2-rc.7'])
+    expect(options).not.toHaveProperty('shell', true)
+  })
+
+  it('win32：spawn 选项含 cwd / stdio / windowsHide，保持原行为面', async () => {
+    platform(true)
+    const child = stubChild()
+    spawnMock.mockReturnValue(child)
+
+    const p = installNpmVersion('0.1.2-rc.7', '/tmp/profile')
+    const exitHandler = child.on.mock.calls.find(([ev]) => ev === 'exit')?.[1] as (code: number | null) => void
+    exitHandler(0)
+    await p
+
+    const [, , options] = spawnMock.mock.calls[0]!
+    expect(options).toMatchObject({ cwd: '/tmp/profile', stdio: 'ignore', windowsHide: true })
+  })
+
+  it('非 win32：保持 spawn pnpm + args，shell 不为 true', async () => {
+    platform(false)
+    const child = stubChild()
+    spawnMock.mockReturnValue(child)
+
+    const p = installNpmVersion('0.1.2-rc.7', '/tmp/profile')
+    const exitHandler = child.on.mock.calls.find(([ev]) => ev === 'exit')?.[1] as (code: number | null) => void
+    exitHandler(0)
+    await p
+
+    const [command, args, options] = spawnMock.mock.calls[0]!
+    expect(command).toBe('pnpm')
+    expect(args).toEqual(['add', '@huiliyi37/dsh-tianshu-tui@0.1.2-rc.7'])
+    expect(options).not.toHaveProperty('shell', true)
+  })
+
+  it('任何平台：spawn 调用都不允许 shell:true 与 args 数组同现（DEP0190 硬约束）', async () => {
+    platform(true)
+    const child = stubChild()
+    spawnMock.mockReturnValue(child)
+
+    const p = installNpmVersion('0.1.2-rc.7', '/tmp/profile')
+    const exitHandler = child.on.mock.calls.find(([ev]) => ev === 'exit')?.[1] as (code: number | null) => void
+    exitHandler(0)
+    await p
+
+    for (const call of spawnMock.mock.calls) {
+      const [, args, options] = call
+      const shellTrue = options && (options as { shell?: unknown }).shell === true
+      expect(shellTrue && Array.isArray(args) && args.length > 0).toBe(false)
+    }
+  })
+
+  it('exit code 非 0 → reject；超时 → kill + reject', async () => {
+    platform(true)
+    const child = stubChild()
+    spawnMock.mockReturnValue(child)
+
+    const pFail = installNpmVersion('0.1.2-rc.7', '/tmp/profile')
+    const exitHandler = child.on.mock.calls.find(([ev]) => ev === 'exit')?.[1] as (code: number | null) => void
+    exitHandler(2)
+    await expect(pFail).rejects.toThrow(/exited 2/)
+
+    spawnMock.mockClear()
+    child.on.mockClear()
+    child.kill.mockClear()
+    spawnMock.mockReturnValue(child)
+    const pTimeout = installNpmVersion('0.1.2-rc.7', '/tmp/profile', 20)
+    // 先挂 rejection handler，避免 20ms 定时器触发 reject 后出现 unhandled 窗口
+    const assertion = expect(pTimeout).rejects.toThrow(/timed out/)
+    await new Promise((r) => setTimeout(r, 60))
+    expect(child.kill).toHaveBeenCalled()
+    await assertion
+  })
+})


### PR DESCRIPTION
## 问题

`installNpmVersion` 以 `spawn('pnpm', [...args], { shell: process.platform === 'win32' })` 执行自更新 `pnpm add`。Node 22+ 对 **shell:true 同时传 args 数组**的组合触发 DEP0190 弃用警告：

```
(node:12996) [DEP0190] DeprecationWarning: Passing args to a child process
with shell option true can lead to security vulnerabilities, as the
arguments are not escaped, only concatenated.
```

该警告输出到 stderr，被 TUI 渲染进**输入框区域**（用户报告的上屏乱码）。首次启动检测到新版本并执行自更新时必现；更新完成重启后不再触发（版本已最新），因此表现为"偶发"。

**根因证据**：Windows 下 `spawn('pnpm.cmd', args)` 抛 EINVAL、`spawn('pnpm', args)` 抛 ENOENT（pnpm 是 .cmd shim），原代码因此用了 shell:true——但 shell:true + args 恰好是 DEP0190 的触发条件，且 args 未转义存在拼接注入面。

## 修复

Windows 上改经 `cmd.exe /d /s /c` 显式派发（shell:false，args 作为 argv 传给 cmd.exe），非 Windows 保持 `spawn('pnpm', args)` 直启。`windowsHide: true` 统一补齐。version 来自 npm registry 的 semver 字符串（无空格/引号/重定向等元字符），拼接安全。

## 验证

- 新增 `tests/install-npm-version.spec.ts`（5 用例）：win32 分支经 cmd.exe 派发且 shell 不为 true、选项面保持、非 win32 直启、**任何平台禁止 shell:true+args 同现**、超时/非零退出契约保持
- RED→GREEN：修复前新测试 3 failed（win32 分支），修复后全绿
- `npm run typecheck` 通过；全量 `npx vitest run` 1657 passed / 12 failed（12 个为既有 Windows 平台相关失败：external-editor .sh 脚本、image-attach sips 断言、app Ctrl+O——与本次改动无关）
- `lib/index.js` 已同步重建（github 安装不重建，产物随仓跟踪）