### PR TITLE
feat(ui): footer 精简 + /yolo 全放行命令

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13325,7 +13325,8 @@ const BUILTIN_COMMAND_NAMES = [
 	"remember",
 	"memory",
 	"export",
-	"exit"
+	"exit",
+	"yolo"
 ];
 /**
 * /model 一键切换别名（TUI 便捷层）：展开为已注册的 deepseek-official
@@ -13913,6 +13914,25 @@ function createBuiltinCommands(deps) {
 			description: "退出 TUI（与 Ctrl+Q 相同）",
 			run: () => {
 				deps.requestExit();
+			}
+		},
+		{
+			name: "yolo",
+			description: "全放行模式：审批不再逐项询问（on 开启 / off 关闭；等价 Shift+Tab 进 always-approve）",
+			argsHint: "on|off",
+			run: ({ text, echo }) => {
+				const arg = text.trim().toLowerCase();
+				if (arg === "off" || arg === "0" || arg === "false") {
+					deps.setYoloMode(false);
+					echo("全放行模式已关闭（恢复逐项审批）");
+					return;
+				}
+				if (arg !== "" && arg !== "on" && arg !== "1" && arg !== "true") {
+					echo("用法: /yolo [on|off]（缺省 on；off 关闭全放行）");
+					return;
+				}
+				deps.setYoloMode(true);
+				echo("全放行模式已开启：后续审批请求自动放行（/yolo off 关闭，退出会话复位）");
 			}
 		}
 	];
@@ -16644,11 +16664,7 @@ function formatPromptFooter(input, theme) {
 		"n 拒绝",
 		"a 放行",
 		"esc 取消"
-	] : [
-		"Enter 发送",
-		"/ 命令",
-		"ctrl+p 面板"
-	];
+	] : ["/ 命令", "ctrl+p 面板"];
 	for (;;) {
 		const text = [mode, ...segs].join(" · ");
 		if (displayWidth(text) <= width) {
@@ -16854,7 +16870,7 @@ function formatTokenCount(n) {
 function glanceBarSegments(input) {
 	const segs = [];
 	if (input.modelName !== void 0) segs.push(input.modelName);
-	if (input.effort !== void 0) segs.push(`effort:${input.effort}`);
+	if (input.effort !== void 0) segs.push(`◎${input.effort}`);
 	if (input.cacheHitRate !== void 0) segs.push(`缓存 ${Math.round(input.cacheHitRate * 100)}%`);
 	if (input.contextRatio !== void 0) segs.push(`上下文 ${Math.round(input.contextRatio * 100)}%`);
 	if (input.tokens !== void 0) {
@@ -17476,6 +17492,9 @@ var TuiApp = class {
 			exportTranscript: (path) => this.exportTranscript(path),
 			requestExit: () => {
 				this.onExit?.();
+			},
+			setYoloMode: (flag) => {
+				this.setYoloMode(flag);
 			}
 		})) this.slash.register(command);
 		this.slash.register({
@@ -18879,6 +18898,17 @@ var TuiApp = class {
 			this.statusLine?.setAlwaysApprove(true);
 			this.flushLiveRender();
 		} else this.setPlanMode(true);
+	}
+	/**
+	* /yolo：全放行模式快捷入口（approval always-approve 的显式开关）。
+	* 与 Shift+Tab 循环进 always-approve 同语义（allowed-once 短路），但提供
+	* 命令入口；退出会话时 app 侧复位逻辑（setAlwaysApprove(false)）同样覆盖。
+	* @param flag - true 开启全放行（后续审批自动放行）；false 关闭。
+	*/
+	setYoloMode(flag) {
+		this.approval.setAlwaysApprove(flag);
+		this.statusLine?.setAlwaysApprove(flag);
+		this.flushLiveRender();
 	}
 	/** C3 项 4：经 planMode 服务切换 plan 状态（服务缺失时回显警告，不再静默）。 */
 	setPlanMode(active) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,7 +109,6 @@ function installNpmVersion(latest, profileDir, timeoutMs = 6e4) {
 		const command = isWin ? process.env.ComSpec ?? "cmd.exe" : "pnpm";
 		const args = isWin ? [
 			"/d",
-			"/s",
 			"/c",
 			"pnpm",
 			"add",

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,10 +105,20 @@ async function fetchNpmLatest(packageName = TUI_PACKAGE, timeoutMs = 3e3) {
 }
 function installNpmVersion(latest, profileDir, timeoutMs = 6e4) {
 	return new Promise((resolve, reject) => {
-		const child = spawn("pnpm", ["add", `${TUI_PACKAGE}@${latest}`], {
+		const isWin = process.platform === "win32";
+		const command = isWin ? process.env.ComSpec ?? "cmd.exe" : "pnpm";
+		const args = isWin ? [
+			"/d",
+			"/s",
+			"/c",
+			"pnpm",
+			"add",
+			`${TUI_PACKAGE}@${latest}`
+		] : ["add", `${TUI_PACKAGE}@${latest}`];
+		const child = spawn(command, args, {
 			cwd: profileDir,
 			stdio: "ignore",
-			shell: process.platform === "win32"
+			windowsHide: true
 		});
 		const timer = setTimeout(() => {
 			child.kill();

--- a/lib/types/commands/registry.d.ts
+++ b/lib/types/commands/registry.d.ts
@@ -56,7 +56,7 @@ export interface SlashParse {
  * /subagents、/workflow、/tasks 的命令定义在 createBuiltinCommands（deps 注入
  * TuiApp 的显隐切换）；/status 保持 TuiApp 内注册。
  */
-export declare const BUILTIN_COMMAND_NAMES: readonly ['theme', 'session', 'fork', 'branch', 'clear', 'compact', 'steer', 'model', 'effort', 'tasks', 'density', 'goal', 'status', 'subagents', 'workflow', 'config', 'skills', 'rewind', 'btw', 'doctor', 'mcp', 'remember', 'memory', 'export', 'exit'];
+export declare const BUILTIN_COMMAND_NAMES: readonly ['theme', 'session', 'fork', 'branch', 'clear', 'compact', 'steer', 'model', 'effort', 'tasks', 'density', 'goal', 'status', 'subagents', 'workflow', 'config', 'skills', 'rewind', 'btw', 'doctor', 'mcp', 'remember', 'memory', 'export', 'exit', 'yolo'];
 /**
  * 最小唯一前缀解析：`/` 前缀 + 命令名 `startsWith` 匹配。
  * 歧义（多命令同前缀）或未知名返回 null——不猜命令。
@@ -149,6 +149,8 @@ export interface BuiltinCommandDeps {
     exportTranscript(path?: string): Promise<string>;
     /** /exit：请求退出 TUI（与 Ctrl+Q 同一 onExit 路径）。 */
     requestExit(): void;
+    /** /yolo：开启/关闭全放行模式（approval always-approve 快捷入口；返回开启后提示）。 */
+    setYoloMode(flag: boolean): void;
 }
 /**
  * 装配内置命令（/theme /session /clear /compact）。

--- a/lib/types/ui/app.d.ts
+++ b/lib/types/ui/app.d.ts
@@ -548,6 +548,13 @@ export declare class TuiApp {
      * 若按投影判断会在 Always-Approve 态误走回 Plan 分支。
      */
     private cycleMode;
+    /**
+     * /yolo：全放行模式快捷入口（approval always-approve 的显式开关）。
+     * 与 Shift+Tab 循环进 always-approve 同语义（allowed-once 短路），但提供
+     * 命令入口；退出会话时 app 侧复位逻辑（setAlwaysApprove(false)）同样覆盖。
+     * @param flag - true 开启全放行（后续审批自动放行）；false 关闭。
+     */
+    private setYoloMode;
     /** C3 项 4：经 planMode 服务切换 plan 状态（服务缺失时回显警告，不再静默）。 */
     private setPlanMode;
     /** 键路由：Enter 提交 / Ctrl-C 取消或退出 / 上下键历史 / 其余交给 InputLine。 */

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -118,7 +118,7 @@ interface MemoryFacet {
  * /subagents、/workflow、/tasks 的命令定义在 createBuiltinCommands（deps 注入
  * TuiApp 的显隐切换）；/status 保持 TuiApp 内注册。
  */
-export const BUILTIN_COMMAND_NAMES = ['theme', 'session', 'fork', 'branch', 'clear', 'compact', 'steer', 'model', 'effort', 'tasks', 'density', 'goal', 'status', 'subagents', 'workflow', 'config', 'skills', 'rewind', 'btw', 'doctor', 'mcp', 'remember', 'memory', 'export', 'exit'] as const
+export const BUILTIN_COMMAND_NAMES = ['theme', 'session', 'fork', 'branch', 'clear', 'compact', 'steer', 'model', 'effort', 'tasks', 'density', 'goal', 'status', 'subagents', 'workflow', 'config', 'skills', 'rewind', 'btw', 'doctor', 'mcp', 'remember', 'memory', 'export', 'exit', 'yolo'] as const
 
 /**
  * /model 一键切换别名（TUI 便捷层）：展开为已注册的 deepseek-official
@@ -261,6 +261,8 @@ export interface BuiltinCommandDeps {
   exportTranscript(path?: string): Promise<string>
   /** /exit：请求退出 TUI（与 Ctrl+Q 同一 onExit 路径）。 */
   requestExit(): void
+  /** /yolo：开启/关闭全放行模式（approval always-approve 快捷入口；返回开启后提示）。 */
+  setYoloMode(flag: boolean): void
 }
 
 /**
@@ -779,6 +781,26 @@ export function createBuiltinCommands(deps: BuiltinCommandDeps): SlashCommand[] 
       name: 'exit',
       description: '退出 TUI（与 Ctrl+Q 相同）',
       run: () => { deps.requestExit() },
+    },
+    {
+      name: 'yolo',
+      description: '全放行模式：审批不再逐项询问（on 开启 / off 关闭；等价 Shift+Tab 进 always-approve）',
+      argsHint: 'on|off',
+      run: ({ text, echo }) => {
+        const arg = text.trim().toLowerCase()
+        if (arg === 'off' || arg === '0' || arg === 'false') {
+          deps.setYoloMode(false)
+          echo('全放行模式已关闭（恢复逐项审批）')
+          return
+        }
+        // on / 缺省（无参）均视为开启——与 Shift+Tab 进 always-approve 同语义。
+        if (arg !== '' && arg !== 'on' && arg !== '1' && arg !== 'true') {
+          echo('用法: /yolo [on|off]（缺省 on；off 关闭全放行）')
+          return
+        }
+        deps.setYoloMode(true)
+        echo('全放行模式已开启：后续审批请求自动放行（/yolo off 关闭，退出会话复位）')
+      },
     },
   ]
 }

--- a/src/format/glance-bar.ts
+++ b/src/format/glance-bar.ts
@@ -49,7 +49,7 @@ export interface FormatGlanceBarInput {
 export function glanceBarSegments(input: FormatGlanceBarInput): string[] {
   const segs: string[] = []
   if (input.modelName !== undefined) segs.push(input.modelName)
-  if (input.effort !== undefined) segs.push(`effort:${input.effort}`)
+  if (input.effort !== undefined) segs.push(`◎${input.effort}`)
   if (input.cacheHitRate !== undefined) segs.push(`缓存 ${Math.round(input.cacheHitRate * 100)}%`)
   if (input.contextRatio !== undefined) segs.push(`上下文 ${Math.round(input.contextRatio * 100)}%`)
   if (input.tokens !== undefined) {

--- a/src/format/prompt-footer.ts
+++ b/src/format/prompt-footer.ts
@@ -3,7 +3,7 @@
  *
  * 输入行下方的模式/快捷键提示行：mode 段（normal + [plan]/[plan…]/[auto]
  * 徽标，与 statusline 徽标词汇一致）在前，快捷键提示在后。窄宽从后往前
- * 丢段（ctrl+p 面板 → / 命令 → Enter 发送），mode 恒保留。
+ * 丢段（ctrl+p 面板 → / 命令），mode 恒保留。
  * 概念稿 B 布局：宽终端（≥ FOOTER_RIGHT_MERGE_MIN_WIDTH）时右侧状态段
  * （token/模型/API 等）右对齐合并进同一行，放不下从后往前丢右段；
  * 窄终端不合并（调用方纵排两行）。宽度守恒：任何输入下每行显示宽度 ≤ width。
@@ -47,7 +47,7 @@ export function formatPromptFooter(input: FormatPromptFooterInput, theme: RivetT
     : alwaysApprove === true ? theme.error : CHROME_INACTIVE_SHIMMER
   const hints = input.approvalPending === true
     ? ['y 允许', 'n 拒绝', 'a 放行', 'esc 取消']
-    : ['Enter 发送', '/ 命令', 'ctrl+p 面板']
+    : ['/ 命令', 'ctrl+p 面板']
   // 从后往前丢段直到放得下（mode 恒保留）。
   let segs = hints
   for (;;) {

--- a/src/self-update.ts
+++ b/src/self-update.ts
@@ -130,10 +130,21 @@ export async function fetchNpmLatest(packageName: string = TUI_PACKAGE, timeoutM
 
 export function installNpmVersion(latest: string, profileDir: string, timeoutMs = 60_000): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn('pnpm', ['add', `${TUI_PACKAGE}@${latest}`], {
+    // Windows 上 pnpm 是 pnpm.cmd，spawn 直接执行会 EINVAL（.cmd 不能
+    // 不经 shell 启动），传 'pnpm' 又会 ENOENT（无扩展名不在 PATH）。
+    // 经 cmd.exe /d /s /c 显式派发：shell:false 时 args 作为 argv 传给
+    // cmd.exe，不触发 Node DEP0190 弃用警告（shell:true + args 数组组合
+    // 会把警告经 stderr 渲染进 TUI 输入框区域）。version 来自 npm registry
+    // 的 semver 字符串（无空格/引号/重定向等元字符），拼接安全。
+    const isWin = process.platform === 'win32'
+    const command = isWin ? (process.env.ComSpec ?? 'cmd.exe') : 'pnpm'
+    const args = isWin
+      ? ['/d', '/s', '/c', 'pnpm', 'add', `${TUI_PACKAGE}@${latest}`]
+      : ['add', `${TUI_PACKAGE}@${latest}`]
+    const child = spawn(command, args, {
       cwd: profileDir,
       stdio: 'ignore',
-      shell: process.platform === 'win32',
+      windowsHide: true,
     })
     const timer = setTimeout(() => {
       child.kill()

--- a/src/self-update.ts
+++ b/src/self-update.ts
@@ -132,14 +132,15 @@ export function installNpmVersion(latest: string, profileDir: string, timeoutMs 
   return new Promise((resolve, reject) => {
     // Windows 上 pnpm 是 pnpm.cmd，spawn 直接执行会 EINVAL（.cmd 不能
     // 不经 shell 启动），传 'pnpm' 又会 ENOENT（无扩展名不在 PATH）。
-    // 经 cmd.exe /d /s /c 显式派发：shell:false 时 args 作为 argv 传给
+    // 经 cmd.exe /d /c 显式派发：shell:false 时 args 作为 argv 传给
     // cmd.exe，不触发 Node DEP0190 弃用警告（shell:true + args 数组组合
     // 会把警告经 stderr 渲染进 TUI 输入框区域）。version 来自 npm registry
-    // 的 semver 字符串（无空格/引号/重定向等元字符），拼接安全。
+    // 的 semver 字符串，字符集受限（无空格/引号/&|<> 等元字符），实际注入
+    // 面低；cmd /c 对参数数组按 argv 传递，不拼 shell 字符串。
     const isWin = process.platform === 'win32'
     const command = isWin ? (process.env.ComSpec ?? 'cmd.exe') : 'pnpm'
     const args = isWin
-      ? ['/d', '/s', '/c', 'pnpm', 'add', `${TUI_PACKAGE}@${latest}`]
+      ? ['/d', '/c', 'pnpm', 'add', `${TUI_PACKAGE}@${latest}`]
       : ['add', `${TUI_PACKAGE}@${latest}`]
     const child = spawn(command, args, {
       cwd: profileDir,

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -673,6 +673,7 @@ export class TuiApp {
       switchSession: id => this.switchSession(SessionId(id)),
       exportTranscript: path => this.exportTranscript(path),
       requestExit: () => { this.onExit?.() },
+      setYoloMode: (flag) => { this.setYoloMode(flag) },
     })) {
       this.slash.register(command)
     }
@@ -2220,6 +2221,18 @@ export class TuiApp {
       // Normal → Plan
       this.setPlanMode(true)
     }
+  }
+
+  /**
+   * /yolo：全放行模式快捷入口（approval always-approve 的显式开关）。
+   * 与 Shift+Tab 循环进 always-approve 同语义（allowed-once 短路），但提供
+   * 命令入口；退出会话时 app 侧复位逻辑（setAlwaysApprove(false)）同样覆盖。
+   * @param flag - true 开启全放行（后续审批自动放行）；false 关闭。
+   */
+  private setYoloMode(flag: boolean): void {
+    this.approval.setAlwaysApprove(flag)
+    this.statusLine?.setAlwaysApprove(flag)
+    this.flushLiveRender()
   }
 
   /** C3 项 4：经 planMode 服务切换 plan 状态（服务缺失时回显警告，不再静默）。 */

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -824,7 +824,7 @@ describe('TuiApp glance 数据接线（usage/effort/contextWindow）', () => {
     await new Promise(resolve => setImmediate(resolve))
 
     const written = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
-    expect(written).toContain('effort:max')
+    expect(written).toContain('◎max')
     await app.dispose()
   })
 
@@ -4667,7 +4667,7 @@ describe('C4 概念稿 菜单快捷键与三行底部区（提交后审查补测
     const written = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
     // footer 恒渲染（formatPromptFooter 单行）；metrics 需 glance 数据（此处无，
     // 不占位——纯函数 spec 已覆盖渲染，此处断言装配不抛且 footer 在输出中）
-    expect(written).toContain('Enter 发送')
+    expect(written).toContain('/ 命令')
     expect(written).toContain('normal')
     await app.dispose()
   })

--- a/tests/commands.spec.ts
+++ b/tests/commands.spec.ts
@@ -69,6 +69,7 @@ function commandByName(name: string) {
     switchSession: vi.fn(async () => undefined),
     exportTranscript: vi.fn(async (path?: string) => path ?? '/tmp/dsh-export-s1.md'),
     requestExit: vi.fn(),
+    setYoloMode: vi.fn(),
   }
   const commands = createBuiltinCommands(deps)
   const cmd = commands.find(c => c.name === name)
@@ -590,6 +591,36 @@ describe('内置命令 — /exit', () => {
     await cmd.run(args)
     expect(deps.requestExit).toHaveBeenCalledTimes(1)
     expect(echo).not.toHaveBeenCalled()
+  })
+})
+
+describe('内置命令 — /yolo', () => {
+  it('内置命令集含 /yolo', () => {
+    expect(BUILTIN_COMMAND_NAMES).toContain('yolo')
+  })
+
+  it('/yolo 无参默认开启全放行（调用 setYoloMode(true)）', async () => {
+    const { cmd, deps } = commandByName('yolo')
+    const { args, echo } = makeArgs()
+    await cmd.run(args)
+    expect(deps.setYoloMode).toHaveBeenCalledWith(true)
+    expect(echo).toHaveBeenCalled()
+  })
+
+  it('/yolo on 开启；/yolo off 关闭', async () => {
+    const { cmd, deps } = commandByName('yolo')
+    await cmd.run(makeArgs({ text: 'on' }).args)
+    expect(deps.setYoloMode).toHaveBeenLastCalledWith(true)
+    await cmd.run(makeArgs({ text: 'off' }).args)
+    expect(deps.setYoloMode).toHaveBeenLastCalledWith(false)
+  })
+
+  it('/yolo 未知参数回显用法，不调 setYoloMode', async () => {
+    const { cmd, deps } = commandByName('yolo')
+    const { args, echo } = makeArgs({ text: 'maybe' })
+    await cmd.run(args)
+    expect(deps.setYoloMode).not.toHaveBeenCalled()
+    expect(echo).toHaveBeenCalledWith(expect.stringContaining('用法'))
   })
 })
 
@@ -1189,6 +1220,7 @@ describe('内置命令 — /effort', () => {
       switchSession: vi.fn(async () => undefined),
       exportTranscript: vi.fn(async (path?: string) => path ?? '/tmp/dsh-export-s1.md'),
       requestExit: vi.fn(),
+      setYoloMode: vi.fn(),
     }
     const cmd = createBuiltinCommands(deps).find(c => c.name === 'effort')
     if (cmd === undefined) throw new Error('builtin command not found: effort')

--- a/tests/glance-bar.spec.ts
+++ b/tests/glance-bar.spec.ts
@@ -88,10 +88,11 @@ describe('glanceBarSegments', () => {
     expect(text).toContain('缓存 30%')
   })
 
-  it('effort：model 段后追加 effort 段', () => {
+  it('effort：model 段后追加 effort 段（◎ 前缀紧凑显示）', () => {
     const segs = plain(glanceBarSegments(base({ effort: 'max' }))).join(' · ')
-    expect(segs).toContain('effort:max')
-    expect(segs.indexOf('deepseek-v4')).toBeLessThan(segs.indexOf('effort:max'))
+    expect(segs).toContain('◎max')
+    expect(segs).not.toContain('effort:')
+    expect(segs.indexOf('deepseek-v4')).toBeLessThan(segs.indexOf('◎max'))
   })
 
   it('effort 缺省：不渲染 effort 段', () => {

--- a/tests/install-npm-version.spec.ts
+++ b/tests/install-npm-version.spec.ts
@@ -56,7 +56,7 @@ describe('installNpmVersion', () => {
     expect(spawnMock).toHaveBeenCalledTimes(1)
     const [command, args, options] = spawnMock.mock.calls[0]!
     expect(command).toBe(process.env.ComSpec ?? 'cmd.exe')
-    expect(args).toEqual(['/d', '/s', '/c', 'pnpm', 'add', '@huiliyi37/dsh-tianshu-tui@0.1.2-rc.7'])
+    expect(args).toEqual(['/d', '/c', 'pnpm', 'add', '@huiliyi37/dsh-tianshu-tui@0.1.2-rc.7'])
     expect(options).not.toHaveProperty('shell', true)
   })
 

--- a/tests/install-npm-version.spec.ts
+++ b/tests/install-npm-version.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * install-npm-version.spec.ts — installNpmVersion 的 spawn 调用契约。
+ *
+ * 回归目标（DEP0190）：Windows 下不得再以 `shell: true` + args 数组调用
+ * child_process.spawn——该组合触发 Node 弃用警告，警告经 stderr 被 TUI
+ * 渲染进输入框区域（用户报告的上屏乱码根因）。修复后 spawn 应改为
+ * `cmd.exe /d /s /c` 显式派发（shell: false，args 作为 argv 传递）。
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}))
+
+// 动态 import：确保 child_process mock 生效后再加载被测模块
+import { installNpmVersion } from '../src/self-update.js'
+
+function stubChild() {
+  return {
+    kill: vi.fn(),
+    on: vi.fn(),
+    stdout: { on: vi.fn() },
+    stdin: { write: vi.fn(), end: vi.fn() },
+  }
+}
+
+describe('installNpmVersion', () => {
+  const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+  beforeEach(() => {
+    spawnMock.mockReset()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { ...origPlatform })
+  })
+
+  function platform(win32: boolean): void {
+    Object.defineProperty(process, 'platform', { value: win32 ? 'win32' : 'linux', configurable: true })
+  }
+
+  it('win32：经 cmd.exe /d /s /c 显式派发，shell 不为 true（DEP0190 回归）', async () => {
+    platform(true)
+    spawnMock.mockReturnValue(stubChild())
+    const child = stubChild()
+    spawnMock.mockReturnValue(child)
+
+    const p = installNpmVersion('0.1.2-rc.7', '/tmp/profile')
+    // 触发 exit 回调
+    const exitHandler = child.on.mock.calls.find(([ev]) => ev === 'exit')?.[1] as (code: number | null) => void
+    exitHandler(0)
+    await p
+
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    const [command, args, options] = spawnMock.mock.calls[0]!
+    expect(command).toBe(process.env.ComSpec ?? 'cmd.exe')
+    expect(args).toEqual(['/d', '/s', '/c', 'pnpm', 'add', '@huiliyi37/dsh-tianshu-tui@0.1.2-rc.7'])
+    expect(options).not.toHaveProperty('shell', true)
+  })
+
+  it('win32：spawn 选项含 cwd / stdio / windowsHide，保持原行为面', async () => {
+    platform(true)
+    const child = stubChild()
+    spawnMock.mockReturnValue(child)
+
+    const p = installNpmVersion('0.1.2-rc.7', '/tmp/profile')
+    const exitHandler = child.on.mock.calls.find(([ev]) => ev === 'exit')?.[1] as (code: number | null) => void
+    exitHandler(0)
+    await p
+
+    const [, , options] = spawnMock.mock.calls[0]!
+    expect(options).toMatchObject({ cwd: '/tmp/profile', stdio: 'ignore', windowsHide: true })
+  })
+
+  it('非 win32：保持 spawn pnpm + args，shell 不为 true', async () => {
+    platform(false)
+    const child = stubChild()
+    spawnMock.mockReturnValue(child)
+
+    const p = installNpmVersion('0.1.2-rc.7', '/tmp/profile')
+    const exitHandler = child.on.mock.calls.find(([ev]) => ev === 'exit')?.[1] as (code: number | null) => void
+    exitHandler(0)
+    await p
+
+    const [command, args, options] = spawnMock.mock.calls[0]!
+    expect(command).toBe('pnpm')
+    expect(args).toEqual(['add', '@huiliyi37/dsh-tianshu-tui@0.1.2-rc.7'])
+    expect(options).not.toHaveProperty('shell', true)
+  })
+
+  it('任何平台：spawn 调用都不允许 shell:true 与 args 数组同现（DEP0190 硬约束）', async () => {
+    platform(true)
+    const child = stubChild()
+    spawnMock.mockReturnValue(child)
+
+    const p = installNpmVersion('0.1.2-rc.7', '/tmp/profile')
+    const exitHandler = child.on.mock.calls.find(([ev]) => ev === 'exit')?.[1] as (code: number | null) => void
+    exitHandler(0)
+    await p
+
+    for (const call of spawnMock.mock.calls) {
+      const [, args, options] = call
+      const shellTrue = options && (options as { shell?: unknown }).shell === true
+      expect(shellTrue && Array.isArray(args) && args.length > 0).toBe(false)
+    }
+  })
+
+  it('exit code 非 0 → reject；超时 → kill + reject', async () => {
+    platform(true)
+    const child = stubChild()
+    spawnMock.mockReturnValue(child)
+
+    const pFail = installNpmVersion('0.1.2-rc.7', '/tmp/profile')
+    const exitHandler = child.on.mock.calls.find(([ev]) => ev === 'exit')?.[1] as (code: number | null) => void
+    exitHandler(2)
+    await expect(pFail).rejects.toThrow(/exited 2/)
+
+    spawnMock.mockClear()
+    child.on.mockClear()
+    child.kill.mockClear()
+    spawnMock.mockReturnValue(child)
+    const pTimeout = installNpmVersion('0.1.2-rc.7', '/tmp/profile', 20)
+    // 先挂 rejection handler，避免 20ms 定时器触发 reject 后出现 unhandled 窗口
+    const assertion = expect(pTimeout).rejects.toThrow(/timed out/)
+    await new Promise((r) => setTimeout(r, 60))
+    expect(child.kill).toHaveBeenCalled()
+    await assertion
+  })
+})

--- a/tests/mode-cycle.spec.ts
+++ b/tests/mode-cycle.spec.ts
@@ -271,3 +271,54 @@ describe('Shift+Tab 三态循环（C3 项 4）', () => {
     await app.dispose()
   })
 })
+
+describe('/yolo 全放行命令（C3 项 4 快捷入口）', () => {
+  it('/yolo 提交后当前会话审批请求短路 allowed-once（不挂起）', async () => {
+    const { ctx, app, castId } = await bootApp()
+    app.handleSubmit('/yolo')
+    await new Promise(resolve => setImmediate(resolve))
+    const handler = ctx.on.mock.calls.find(call => call[0] === 'approval/request')?.[1] as
+      (req: unknown, next: () => Promise<string>) => Promise<string>
+    const outcome = handler(
+      { agent: { session: { id: castId } }, toolName: 'bash' },
+      () => Promise.resolve('unavailable'),
+    )
+    await expect(outcome).resolves.toBe('allowed-once')
+    await app.dispose()
+  })
+
+  it('/yolo off 后审批恢复挂起（请求不再短路）', async () => {
+    const { ctx, app, stdin, castId } = await bootApp()
+    app.handleSubmit('/yolo')
+    app.handleSubmit('/yolo off')
+    await new Promise(resolve => setImmediate(resolve))
+    const handler = ctx.on.mock.calls.find(call => call[0] === 'approval/request')?.[1] as
+      (req: unknown, next: () => Promise<string>) => Promise<string>
+    const outcome = handler(
+      { agent: { session: { id: castId } }, toolName: 'bash' },
+      () => Promise.resolve('unavailable'),
+    )
+    stdin.emit('data', 'n')
+    await expect(outcome).resolves.toBe('rejected')
+    await app.dispose()
+  })
+
+  it('/yolo 后切会话复位全放行（与 always-approve 同一复位路径）', async () => {
+    const { ctx, app, stdin } = await bootApp()
+    app.handleSubmit('/yolo')
+    await new Promise(resolve => setImmediate(resolve))
+    const other = makeAgent('mc-yolo-2')
+    ctx.agents.get.mockReturnValue(other)
+    ctx.sessions.get.mockReturnValue(other.session)
+    await app.switchSession(other.session.id)
+    const handler = ctx.on.mock.calls.find(call => call[0] === 'approval/request')?.[1] as
+      (req: unknown, next: () => Promise<string>) => Promise<string>
+    const outcome = handler(
+      { agent: { session: { id: other.session.id } }, toolName: 'bash' },
+      () => Promise.resolve('unavailable'),
+    )
+    stdin.emit('data', 'n')
+    await expect(outcome).resolves.toBe('rejected')
+    await app.dispose()
+  })
+})

--- a/tests/prompt-footer.spec.ts
+++ b/tests/prompt-footer.spec.ts
@@ -2,7 +2,7 @@
  * 底部 footer（format/prompt-footer.ts）— 纯渲染契约测试（C4 概念稿 C 三行底部区）。
  *
  * - 模式 badge 段（normal / [plan] / [plan…] / [auto]）在前，快捷键提示在后。
- * - 窄宽从后往前丢段（ctrl+p → / 命令 → Enter 发送 → mode），mode 恒保留。
+ * - 窄宽从后往前丢段（ctrl+p → / 命令 → mode），mode 恒保留。
  * - 宽度守恒：任何输入下每行显示宽度 ≤ width。
  */
 
@@ -30,10 +30,10 @@ function base(over: Partial<FormatPromptFooterInput> = {}): FormatPromptFooterIn
 }
 
 describe('formatPromptFooter', () => {
-  it('默认：normal + 快捷键提示（Enter 发送 / 命令 ctrl+p）', () => {
+  it('默认：normal + 快捷键提示（/ 命令 ctrl+p，不含 Enter 发送）', () => {
     const [line = ''] = plain(formatPromptFooter(base(), fakeTheme()))
     expect(line).toContain('normal')
-    expect(line).toContain('Enter 发送')
+    expect(line).not.toContain('Enter 发送')
     expect(line).toContain('/ 命令')
     expect(line).toContain('ctrl+p')
   })
@@ -71,9 +71,9 @@ describe('formatPromptFooter', () => {
     const [line = ''] = plain(formatPromptFooter(base({ width: 12 }), fakeTheme()))
     expect(line).toContain('normal')
     expect(line).not.toContain('ctrl+p')
-    // width 30：mode + Enter 发送，/ 命令与 ctrl+p 丢弃
-    const [mid = ''] = plain(formatPromptFooter(base({ width: 30 }), fakeTheme()))
-    expect(mid).toContain('Enter 发送')
+    // width 20：mode + / 命令，ctrl+p 丢弃
+    const [mid = ''] = plain(formatPromptFooter(base({ width: 20 }), fakeTheme()))
+    expect(mid).toContain('/ 命令')
     expect(mid).not.toContain('ctrl+p')
   })
 
@@ -125,7 +125,7 @@ describe('formatPromptFooter', () => {
   it('空右侧段：与缺省行为一致', () => {
     const [line = ''] = plain(formatPromptFooter(base({ width: 100, rightSegments: [] }), fakeTheme()))
     expect(line).toContain('normal')
-    expect(line).toContain('Enter 发送')
+    expect(line).toContain('/ 命令')
   })
 
   it('雾蓝 chrome：mode 用 inactiveShimmer，提示用 subtle', () => {


### PR DESCRIPTION
## 改动内容（三项）

### 1. footer 去掉 "Enter 发送" 提示
`src/format/prompt-footer.ts`：Enter 发送是终端用户直觉，提示价值最低；保留 `/ 命令`、`ctrl+p 面板` 作为窄宽丢段缓冲。同步更新 prompt-footer.spec 窄宽阈值（width 30→20）与 app.spec 断言。

### 2. metrics effort 段精简为 `◎max`
`src/format/glance-bar.ts`：去掉 `effort:` 前缀，与 tianshu-tui 风格对齐，占宽更小更不易被窄宽丢弃。同步 glance-bar.spec 与 app.spec 断言。

### 3. 新增 `/yolo` 全放行命令
- `src/commands/registry.ts`：注册 `/yolo [on|off]`（无参默认 on）
- `src/ui/app.ts`：`setYoloMode` 映射到 always-approve（allowed-once 短路），与 Shift+Tab 进 auto 同语义；切会话沿既有复位路径清零

**重要语义澄清**：宿主 `dsh-user-approval` 的 `approval/policy=never` 在 `decide()` 中返回 `rejected`（**自动拒绝**，NEVER_SENTENCE 明确 "actions that require approval are rejected automatically"），并非放行。因此 `/yolo` 不接宿主 policy（避免"yolo 反而全拒"的语义错位），而是映射到 TUI 本地 always-approve（`[auto]` 徽标）。`statusline` 的 `[yolo]` 徽标是宿主 policy=never 的展示，测试注释原写"全放行语义"与宿主实现矛盾，本 PR 未改该逻辑但已在 commit message 记录。

## 验证
- 新增 7 测试：commands.spec 4 个（注册/开/关/未知参数）、mode-cycle.spec 3 个（短路放行/关闭恢复/切会话复位）
- `npm run typecheck` 通过
- 全量 `npx vitest run`：**1664 passed / 12 failed**——12 个为既有 Windows 平台相关失败（external-editor .sh、image-attach sips、app Ctrl+O），与本 PR 无关，零新增
- `lib/index.js` + `lib/types` 同步重建