### PR TITLE
docs: warn about ecosystem boundary — plugin is for official dsh, not oh-my-tianshu

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -11,6 +11,10 @@
 
 **dsh-tianshu-tui** (`@huiliyi37/dsh-tianshu-tui`) is the interactive terminal UI plugin for the official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness). The render core evolved from [Tianshu-Tui](https://github.com/huiliyi37/Tianshu-Tui) (Apache-2.0; file-by-file provenance in [SOURCE-MAP.md](SOURCE-MAP.md)). The UI is a pure presentation layer: every piece of agent state arrives through the session event stream.
 
+
+> [!WARNING]
+> **Ecosystem boundary**: this plugin belongs to the official [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) ecosystem (`@deepseek-ai/*` scope) — its peerDependencies and imports all point at `@deepseek-ai/*`. **Do not assemble it into an oh-my-tianshu (`@huiliyi37` scope, CLI `@huiliyi37/dsh-tianshu`) tui profile.** oh-my-tianshu ships its own official TUI, `@huiliyi37/dsh-tui`: the two share 109 of 117 TUI source files but live in different ecosystems. Mixing them makes the plugin resolve `@deepseek-ai/*` at runtime through stale symlinks under `~/.dsh/profiles/node_modules` pointing at the globally installed official dsh — a fragile cross-ecosystem coupling.
+
 ## Documentation
 
 | Doc | What it covers |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 **dsh-tianshu-tui**（`@huiliyi37/dsh-tianshu-tui`）是官方 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 上的交互式终端 UI 插件。渲染核心从 [天枢 Tianshu-Tui](https://github.com/huiliyi37/Tianshu-Tui) 演进而来（Apache-2.0；逐文件来源见 [SOURCE-MAP.md](SOURCE-MAP.md)）。UI 是纯展示层：所有 agent 状态都来自会话事件流。并做了harness工程层的个性化改造。比如TDD驱动的工作流，证据门，图像和视觉桥接，代码智能检索、记忆和跨会话召回等功能。
 
+
+> [!WARNING]
+> **生态边界（Ecosystem boundary）**：本插件属于官方 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（`@deepseek-ai/*` 生态）——peerDependencies 与代码 import 均指向 `@deepseek-ai/*`。**不要把它装配进 oh-my-tianshu（`@huiliyi37` 生态，CLI 为 `@huiliyi37/dsh-tianshu`）的 tui profile**。oh-my-tianshu 的官方 TUI 是 `@huiliyi37/dsh-tui`：两者同源（共享 109/117 个 TUI 源文件）但生态不同，混装会让插件在运行时靠 `~/.dsh/profiles/node_modules` 中指向官方 dsh 的旧符号链接兜底解析 `@deepseek-ai/*`，形成跨生态脆弱耦合。
+
 ## 文档
 
 | 文档 | 说明 |


### PR DESCRIPTION
## 背景

`@huiliyi37/dsh-tianshu-tui` 的 peerDependencies 与代码 import 全部指向 `@deepseek-ai/*`（官方 DeepSeek Harness 生态）。但包名在 `@huiliyi37` scope 下，容易被误装进 oh-my-tianshu（`@huiliyi37` 生态）的 tui profile。

真实事故：用户在 oh-my-tianshu 的 tui profile 中装配本插件后，`tianshu tui` 进入的是本插件界面，运行时靠 `~/.dsh/profiles/node_modules` 中指向全局官方 dsh 的旧符号链接兜底解析 `@deepseek-ai/*`——跨生态脆弱耦合，且与本仓库无关。

oh-my-tianshu 官方 README 亦声明：`The plugin-only distribution (dsh-tianshu-tui as an upstream-dsh plugin) is paused for now; this full monorepo is the maintained line.`

## 改动

两个 README（中/英）在介绍段后加 `[!WARNING]` 生态边界警告，明确：
- 本插件属于官方 DeepSeek Harness（@deepseek-ai 生态）
- 不要装配进 oh-my-tianshu 的 tui profile（其官方 TUI 是 @huiliyi37/dsh-tui）
- 说明混装的后果（运行时跨生态兜底解析）

纯文档改动，无代码影响。