### PR TITLE
fix(ui): session tab labels show [session-] empty shells — strip the id prefix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18760,6 +18760,11 @@ function readAppExit(ctx) {
 	}
 	return ctx.reflect.get("appExit", false);
 }
+/** 会话 tab 短标签：去 session- 前缀后截 8 字符（前缀恰好 8 字符，直接 slice(0,8)
+* 会让所有 tab 显示 [session-] 空壳）；无前缀 id 原样截断。 */
+function shortSessionLabel(id) {
+	return id.replace(/^session-/, "").slice(0, 8) || id.slice(0, 8);
+}
 /** C3 项 3：写工具名判定（与 fs-snapshot 的 trackEdit 钩子同一集合）。 */
 function isWriteToolCall(name) {
 	return name === "write" || name === "edit" || name === "str_replace_editor";
@@ -19732,7 +19737,7 @@ var TuiApp = class {
 		const others = summaries.filter((s) => s.id !== active);
 		this.sessionTabs = summaries.map((row) => ({
 			id: row.id,
-			label: row.id.slice(0, 8),
+			label: shortSessionLabel(row.id),
 			current: row.id === active
 		}));
 		const env = {
@@ -20160,7 +20165,7 @@ var TuiApp = class {
 		const active = this.activeSessionId;
 		this.sessionTabs = rows.map((row) => ({
 			id: row.id,
-			label: row.id.slice(0, 8),
+			label: shortSessionLabel(row.id),
 			current: row.id === active
 		}));
 		this.renderBatcher.schedule();

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -394,6 +394,12 @@ function readAppExit(ctx: Context): ((code?: number) => void) | undefined {
   return ctx.reflect.get('appExit', false) as ((code?: number) => void) | undefined
 }
 
+/** 会话 tab 短标签：去 session- 前缀后截 8 字符（前缀恰好 8 字符，直接 slice(0,8)
+ * 会让所有 tab 显示 [session-] 空壳）；无前缀 id 原样截断。 */
+function shortSessionLabel(id: string): string {
+  return id.replace(/^session-/, '').slice(0, 8) || id.slice(0, 8)
+}
+
 /** C3 项 3：写工具名判定（与 fs-snapshot 的 trackEdit 钩子同一集合）。 */
 function isWriteToolCall(name: string): boolean {
   return name === 'write' || name === 'edit' || name === 'str_replace_editor'
@@ -1513,7 +1519,7 @@ export class TuiApp {
     // 会话 tab 栏初始快照(attach 后;后续 newSession/switchSession 刷新)。
     this.sessionTabs = summaries.map(row => ({
       id: row.id,
-      label: row.id.slice(0, 8),
+      label: shortSessionLabel(row.id),
       current: row.id === active,
     }))
 
@@ -1939,7 +1945,7 @@ export class TuiApp {
     const active = this.activeSessionId
     this.sessionTabs = rows.map(row => ({
       id: row.id,
-      label: row.id.slice(0, 8),
+      label: shortSessionLabel(row.id),
       current: row.id === active,
     }))
     this.renderBatcher.schedule()

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -5304,7 +5304,7 @@ describe('C4 概念稿 菜单快捷键与三行底部区（提交后审查补测
     // tab 栏渲染：短 id + 当前 ●（s1 当前）
     await new Promise(resolve => setTimeout(resolve, 50))
     const written = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
-    expect(written).toContain('session-tab-one'.slice(0, 8) + '●')
+    expect(written).toContain('session-tab-one'.replace(/^session-/, '').slice(0, 8) + '●')
     // Ctrl+X → 下一个（s2）
     stdin.emit('data', '\x18')
     await new Promise(resolve => setTimeout(resolve, 50))
@@ -5317,6 +5317,36 @@ describe('C4 概念稿 菜单快捷键与三行底部区（提交后审查补测
     stdin.emit('data', '\x1b9')
     await new Promise(resolve => setTimeout(resolve, 50))
     expect(app.sessionId).toBe(s3)
+    await app.dispose()
+  })
+
+  it('会话 tab 栏：真实 id 形态（session- 前缀）标签去前缀显示，不出现 [session-] 空壳', async () => {
+    const ctx = makeCtx()
+    const agent = makeAgent('tab-real')
+    const handle = makeHandle(agent)
+    ctx.agents.create.mockResolvedValue(handle)
+    ctx.sessions.get.mockReturnValue(agent.session)
+    const s1 = SessionId('session-aaaabbbbcccc-rest')
+    const s2 = SessionId('session-ddddeeeeffff-rest')
+    const headerOf = (id: SessionId, createdAt: number) => ({
+      id, createdAt, version: 0, cwd: undefined, parentSession: undefined,
+    })
+    ctx.sessions.list.mockReturnValue([
+      { id: s1, header: headerOf(s1, Date.now() - 1_000), events: [] },
+      { id: s2, header: headerOf(s2, Date.now() - 2_000), events: [] },
+    ])
+    ctx.agents.get.mockReturnValue(agent)
+    const stdin = makeStdin()
+    const stdout = makeStdout()
+    const app = new TuiApp({ ctx, stdout, stdin })
+    await app.attach()
+    await new Promise(resolve => setTimeout(resolve, 50))
+    // 数据层断言：label 是去 session- 前缀后的短 id（formatSessionTabs 渲染
+    // [label●] 时不再出现 [session-] 空壳）。
+    // sessionTabs 是 TuiApp 私有成员：测试经类型断言读取（vitest 运行时可见）。
+    const tabs = (app as unknown as { sessionTabs: { label: string }[] }).sessionTabs
+    expect(tabs.map(t => t.label)).toEqual(['aaaabbbb', 'ddddeeee'])
+    expect(tabs.some(t => t.label.includes('session-'))).toBe(false)
     await app.dispose()
   })
 


### PR DESCRIPTION
## 问题

`dsh --profile tui` 进入界面后，输入框上方会话 tab 栏渲染为一行 `[session-] [session-] [session-] ... +14`——**所有会话标签都是空壳**。

## 根因

`src/ui/app.ts` 的会话 tab 标签生成用 `row.id.slice(0, 8)`，而 SessionId 前缀 `session-` **恰好 8 字符**——截出来的全是前缀，没有区分度。两处赋值点（attach 初始快照 + refreshSessionTabs）都有此问题；既有测试断言 `'session-tab-one'.slice(0, 8) + '●'` 固化了 bug 行为。

## 修复

- 新增 `shortSessionLabel(id)`：去 `session-` 前缀后截 8 字符（无前缀 id 原样截断，防御非标准 id）
- 两处 label 生成统一走 helper
- 测试：新增"真实 id 形态"用例（`session-aaaabbbbcccc-rest` → label `aaaabbbb`，不含 `session-`）；既有断言同步为去前缀期望

## 验证（全部实测）

- `app.spec.ts` + `session-tabs.spec.ts` **274/274 通过**（含新增用例）
- `npm run typecheck` exit 0（tsc --noEmit + vision-ask）
- 端到端：构建产物替换 profile 插件后 `dsh --profile tui` boot，`[session-` 出现 **0 次**（修复前必现）；验证后已恢复官方 rc.10
