### PR TITLE
fix(ui): strip session- prefix at remaining id shortening sites + quiet failure paths + ASCII glyphs

### DIFF
--- a/SOURCE-MAP.md
+++ b/SOURCE-MAP.md
@@ -126,6 +126,7 @@ Apache-2.0）；`service.ts`（LspService 封装）、`tools.ts`（三个模型�
 | src/ring-buffer.ts | ring-buffer.ts | modified |
 | src/scrollback-transcript.ts | scrollback-transcript.ts | modified |
 | src/self-update.ts | — | new（启动自更新：对照 npm latest 写 profile，dsh 原创） |
+| src/session-label.ts | — | new（会话 id 显示短标签：剥离 `session-` 前缀后截 8 位，消除空壳 label；PR #37 的同类截断点统一） |
 | src/restart.ts | — | new（#34：同命令行重启原语——argv 重放 + stdio inherit + POSIX detached；/restart 命令与更新后自动重启共用） |
 | src/skill-panel.ts | — | new |
 | src/status-panel.ts | — | new |

--- a/lib/index.js
+++ b/lib/index.js
@@ -12354,18 +12354,30 @@ function formatTurnSummary(input, theme) {
 *
 * @module @deepseek-ai/dsh-tianshu-tui/question-panel
 */
-/** 面板标题行。 */
-const TITLE$5 = "❓ 提问";
+const UNICODE_GLYPHS$1 = {
+	title: "❓ 提问",
+	question: "❓",
+	plan: "🧭",
+	approve: "✓",
+	reject: "✗"
+};
+const ASCII_GLYPHS$1 = {
+	title: "? 提问",
+	question: "?",
+	plan: ">",
+	approve: "+",
+	reject: "x"
+};
+/** 当前终端应使用的字形档（❓/🧭 是彩色 emoji，GBK conhost 下豆腐）。 */
+function questionGlyphs() {
+	return useAsciiGlyphs() ? ASCII_GLYPHS$1 : UNICODE_GLYPHS$1;
+}
 /** 多选标记（尾缀在通用问题行）。 */
 const MULTI_MARK = "（多选）";
 /** 粗体（与 engine/ansi.ts 的 ANSI.BOLD 一致；纯函数层不跨模块依赖）。 */
 const BOLD = "\x1B[1m";
 /** SGR 重置转义序列。 */
 const RESET$2 = "\x1B[0m";
-/** plan-review 批准项标记。 */
-const APPROVE_MARK = "✓";
-/** plan-review 否决项标记。 */
-const REJECT_MARK = "✗";
 /**
 * 投影提问请求为面板行（标题 + 每个 question 一块，按输入顺序）。
 * @param request - 提问请求（只消费 questions 字段）。
@@ -12373,24 +12385,25 @@ const REJECT_MARK = "✗";
 * @returns 面板行数组（空 questions → 仅标题行）。
 */
 function projectQuestionPanel(request, opts) {
-	const rows = [TITLE$5];
+	const rows = [questionGlyphs().title];
 	for (const item of request.questions) rows.push(...projectQuestion(item, opts.width));
 	return rows;
 }
 /** 渲染单个 question 块（header + 问题行 + detail + 选项行；形态由 intent 决定）。 */
 function projectQuestion(item, width) {
 	const rows = [];
+	const g = questionGlyphs();
 	if (item.header !== void 0) rows.push(truncateByWidth$6(`── ${item.header} ──`, width));
 	const intent = item.intent;
 	if (intent?.kind === "plan-review") {
-		rows.push(truncateByWidth$6(`🧭 ${item.question}`, width));
+		rows.push(truncateByWidth$6(`${g.plan} ${item.question}`, width));
 		if (item.detail !== void 0) rows.push(...projectDetail(item.detail, width));
 		rows.push(...projectPlanOptions(item.options, intent.approve, width));
 		rows.push(...projectPlanKeyHints(item, width));
 		return rows;
 	}
 	const multiMark = item.multiSelect === true ? MULTI_MARK : "";
-	rows.push(truncateByWidth$6(`❓ ${item.question}${multiMark}`, width));
+	rows.push(truncateByWidth$6(`${g.question} ${item.question}${multiMark}`, width));
 	if (item.detail !== void 0) rows.push(...projectDetail(item.detail, width));
 	rows.push(...projectOptionList(item.options, width));
 	return rows;
@@ -12405,7 +12418,8 @@ function projectPlanOptions(options, approve, width) {
 	const rows = [];
 	options.forEach((opt, i) => {
 		const isApprove = opt.label === approve;
-		const cut = truncateByWidth$6(`  ${isApprove ? APPROVE_MARK : REJECT_MARK} ${i + 1}. ${opt.label}`, width);
+		const g = questionGlyphs();
+		const cut = truncateByWidth$6(`  ${isApprove ? g.approve : g.reject} ${i + 1}. ${opt.label}`, width);
 		rows.push(isApprove ? `${BOLD}${cut}${RESET$2}` : cut);
 	});
 	return rows;
@@ -12597,6 +12611,28 @@ function truncateByWidth$4(text, max) {
 	return w < displayWidth(text) ? `${out}…` : out;
 }
 //#endregion
+//#region lib/types/session-label.js
+/**
+* session-label — 会话 id 的显示短标签。
+*
+* SessionId 形如 `session-<uuid>`：直接 `slice(0, 8)` 恰好截出常量前缀
+* `session-`，所有展示位（tab 标签、欢迎页可恢复列表、委派树回退、对话流
+* subagent 标签）都会退化为无区分度的空壳。统一经此 helper 剥离前缀后再
+* 截断；非 `session-` 形态的 id（历史/外部形状）行为不变（取前 8 位）。
+*
+* @module @deepseek-ai/dsh-tianshu-tui/session-label
+*/
+/** `session-` 前缀的长度（8）——与短标签长度相同，正是空壳病灶的来源。 */
+const SESSION_ID_PREFIX = "session-";
+/**
+* 会话 id → 8 位显示短标签（剥离 `session-` 前缀后截断）。
+* @param id - 会话 id（`session-<uuid>` 或其他形状）。
+* @returns 8 位短标签；空 id 返回空串。
+*/
+function shortSessionLabel(id) {
+	return (id.startsWith(SESSION_ID_PREFIX) ? id.slice(8) : id).slice(0, 8);
+}
+//#endregion
 //#region lib/types/delegation-panel.js
 /**
 * 委派树面板（grok-build tasks_pane 分组行移植，纯函数层）。
@@ -12629,9 +12665,9 @@ function reasonLabel(reason) {
 	if (reason === "unavailable") return "不可用";
 	return "不支持";
 }
-/** id 前 8 位短哈希（label 缺失回退）。 */
+/** id 前 8 位短哈希（label 缺失回退；`session-` 前缀已剥离）。 */
 function shortHash(id) {
-	return id.slice(0, 8);
+	return shortSessionLabel(id);
 }
 /** settledMs → 秒文本（一位小数）。 */
 function formatSettled(ms) {
@@ -19702,7 +19738,7 @@ var TuiApp = class {
 	* live store 没有时走 switchSession → resume。
 	*/
 	async restoreRecentOtherSession() {
-		const target = (await listSessions(this.ctx)).filter((s) => s.id !== this.activeSessionId)[0]?.id;
+		const target = (await listSessions(this.ctx).catch(() => [])).filter((s) => s.id !== this.activeSessionId)[0]?.id;
 		if (target !== void 0) await this.switchSession(target);
 	}
 	/**
@@ -20387,8 +20423,8 @@ var TuiApp = class {
 	* @returns 显示标签。
 	*/
 	subagentLabel(id) {
-		for (const e of this.delegationEntries ?? []) if (e.kind === "child" && e.id === id) return e.label ?? id.slice(0, 8);
-		return id.slice(0, 8);
+		for (const e of this.delegationEntries ?? []) if (e.kind === "child" && e.id === id) return e.label ?? shortSessionLabel(id);
+		return shortSessionLabel(id);
 	}
 	refreshDelegationTree(sessionId) {
 		const subagents = this.ctx.reflect.get("subagents", false);
@@ -20401,9 +20437,9 @@ var TuiApp = class {
 			this.delegationEntries = entries;
 			this.renderBatcher.schedule();
 		}).catch(() => {
-			/* v8 ignore next -- dispose 后 reject 的竞态守卫（同步测试无法构造） */
 			if (this.disposed) return;
 			this.delegationEntries = null;
+			this.renderBatcher.schedule();
 		});
 	}
 	/** T2.2：运行态缓存项 → 面板视图（终态含 stopReason/agentsStarted）。 */

--- a/lib/types/session-label.d.ts
+++ b/lib/types/session-label.d.ts
@@ -1,0 +1,16 @@
+/**
+ * session-label — 会话 id 的显示短标签。
+ *
+ * SessionId 形如 `session-<uuid>`：直接 `slice(0, 8)` 恰好截出常量前缀
+ * `session-`，所有展示位（tab 标签、欢迎页可恢复列表、委派树回退、对话流
+ * subagent 标签）都会退化为无区分度的空壳。统一经此 helper 剥离前缀后再
+ * 截断；非 `session-` 形态的 id（历史/外部形状）行为不变（取前 8 位）。
+ *
+ * @module @deepseek-ai/dsh-tianshu-tui/session-label
+ */
+/**
+ * 会话 id → 8 位显示短标签（剥离 `session-` 前缀后截断）。
+ * @param id - 会话 id（`session-<uuid>` 或其他形状）。
+ * @returns 8 位短标签；空 id 返回空串。
+ */
+export declare function shortSessionLabel(id: string): string;

--- a/src/delegation-panel.ts
+++ b/src/delegation-panel.ts
@@ -14,6 +14,7 @@
  * @module @deepseek-ai/dsh-tianshu-tui/delegation-panel
  */
 
+import { shortSessionLabel } from './session-label.js'
 import { displayWidth } from './width.js'
 
 /** activity 状态：running 在 store 中存活，inactive 仅存在于持久化。 */
@@ -97,9 +98,9 @@ function reasonLabel(reason: Extract<DelegationTreeEntry, { kind: 'diagnostic' }
   return '不支持'
 }
 
-/** id 前 8 位短哈希（label 缺失回退）。 */
+/** id 前 8 位短哈希（label 缺失回退；`session-` 前缀已剥离）。 */
 function shortHash(id: string): string {
-  return id.slice(0, 8)
+  return shortSessionLabel(id)
 }
 
 /** settledMs → 秒文本（一位小数）。 */

--- a/src/question-panel.ts
+++ b/src/question-panel.ts
@@ -20,6 +20,7 @@
  * @module @deepseek-ai/dsh-tianshu-tui/question-panel
  */
 
+import { useAsciiGlyphs } from './term-caps.js'
 import { displayWidth } from './width.js'
 
 /** 单个可选项（结构兼容 user-questions 的 AskUserQuestionOption）。 */
@@ -68,8 +69,40 @@ export interface QuestionPanelOptions {
   width: number
 }
 
-/** 面板标题行。 */
-const TITLE = '❓ 提问'
+/** 面板字形集：Unicode 档（默认）与 legacy conhost 的 ASCII 降级档。 */
+interface QuestionGlyphs {
+  /** 面板标题行。 */
+  readonly title: string
+  /** 通用问题行前缀标记。 */
+  readonly question: string
+  /** plan-review 决策卡问题行前缀标记。 */
+  readonly plan: string
+  /** plan-review 批准项标记。 */
+  readonly approve: string
+  /** plan-review 否决项标记。 */
+  readonly reject: string
+}
+
+const UNICODE_GLYPHS = {
+  title: '❓ 提问',
+  question: '❓',
+  plan: '🧭',
+  approve: '✓',
+  reject: '✗',
+} as const satisfies QuestionGlyphs
+
+const ASCII_GLYPHS = {
+  title: '? 提问',
+  question: '?',
+  plan: '>',
+  approve: '+',
+  reject: 'x',
+} as const satisfies QuestionGlyphs
+
+/** 当前终端应使用的字形档（❓/🧭 是彩色 emoji，GBK conhost 下豆腐）。 */
+function questionGlyphs(): QuestionGlyphs {
+  return useAsciiGlyphs() ? ASCII_GLYPHS : UNICODE_GLYPHS
+}
 
 /** 多选标记（尾缀在通用问题行）。 */
 const MULTI_MARK = '（多选）'
@@ -80,12 +113,6 @@ const BOLD = '\x1B[1m'
 /** SGR 重置转义序列。 */
 const RESET = '\x1B[0m'
 
-/** plan-review 批准项标记。 */
-const APPROVE_MARK = '✓'
-
-/** plan-review 否决项标记。 */
-const REJECT_MARK = '✗'
-
 /**
  * 投影提问请求为面板行（标题 + 每个 question 一块，按输入顺序）。
  * @param request - 提问请求（只消费 questions 字段）。
@@ -93,7 +120,7 @@ const REJECT_MARK = '✗'
  * @returns 面板行数组（空 questions → 仅标题行）。
  */
 export function projectQuestionPanel(request: QuestionRequestInput, opts: QuestionPanelOptions): string[] {
-  const rows = [TITLE]
+  const rows = [questionGlyphs().title]
   for (const item of request.questions) {
     rows.push(...projectQuestion(item, opts.width))
   }
@@ -103,12 +130,13 @@ export function projectQuestionPanel(request: QuestionRequestInput, opts: Questi
 /** 渲染单个 question 块（header + 问题行 + detail + 选项行；形态由 intent 决定）。 */
 function projectQuestion(item: QuestionItemInput, width: number): string[] {
   const rows: string[] = []
+  const g = questionGlyphs()
   if (item.header !== undefined) {
     rows.push(truncateByWidth(`── ${item.header} ──`, width))
   }
   const intent = item.intent
   if (intent?.kind === 'plan-review') {
-    rows.push(truncateByWidth(`🧭 ${item.question}`, width))
+    rows.push(truncateByWidth(`${g.plan} ${item.question}`, width))
     if (item.detail !== undefined) {
       rows.push(...projectDetail(item.detail, width))
     }
@@ -117,7 +145,7 @@ function projectQuestion(item: QuestionItemInput, width: number): string[] {
     return rows
   }
   const multiMark = item.multiSelect === true ? MULTI_MARK : ''
-  rows.push(truncateByWidth(`❓ ${item.question}${multiMark}`, width))
+  rows.push(truncateByWidth(`${g.question} ${item.question}${multiMark}`, width))
   if (item.detail !== undefined) {
     rows.push(...projectDetail(item.detail, width))
   }
@@ -136,7 +164,8 @@ function projectPlanOptions(options: QuestionOptionInput[] | undefined, approve:
   const rows: string[] = []
   options.forEach((opt, i) => {
     const isApprove = opt.label === approve
-    const mark = isApprove ? APPROVE_MARK : REJECT_MARK
+    const g = questionGlyphs()
+    const mark = isApprove ? g.approve : g.reject
     const row = `  ${mark} ${i + 1}. ${opt.label}`
     const cut = truncateByWidth(row, width)
     rows.push(isApprove ? `${BOLD}${cut}${RESET}` : cut)

--- a/src/restore-session.ts
+++ b/src/restore-session.ts
@@ -6,6 +6,7 @@
  */
 import type { SessionId } from '@deepseek-ai/dsh-session'
 import type { SessionSummary } from './adapter/sessions.js'
+import { shortSessionLabel } from './session-label.js'
 
 /** 可恢复会话视图行（live = 当前进程内仍活跃）。 */
 export interface RestorableSession {
@@ -68,9 +69,9 @@ export function formatSessionAge(createdAt: number, now: number): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
 }
 
-/** 会话 id 的 8 位短引用（`#` 前缀），欢迎页行用可读短 id 替代裸 UUID。 */
+/** 会话 id 的 8 位短引用（`#` 前缀，`session-` 前缀已剥离），欢迎页行用可读短 id 替代裸 UUID。 */
 function shortId(id: SessionId): string {
-  return id.slice(0, 8)
+  return shortSessionLabel(id)
 }
 
 /** cwd 的目录 basename（无尾斜杠）；空/根路径（无 basename）返回 undefined。 */

--- a/src/session-label.ts
+++ b/src/session-label.ts
@@ -1,0 +1,23 @@
+/**
+ * session-label — 会话 id 的显示短标签。
+ *
+ * SessionId 形如 `session-<uuid>`：直接 `slice(0, 8)` 恰好截出常量前缀
+ * `session-`，所有展示位（tab 标签、欢迎页可恢复列表、委派树回退、对话流
+ * subagent 标签）都会退化为无区分度的空壳。统一经此 helper 剥离前缀后再
+ * 截断；非 `session-` 形态的 id（历史/外部形状）行为不变（取前 8 位）。
+ *
+ * @module @deepseek-ai/dsh-tianshu-tui/session-label
+ */
+
+/** `session-` 前缀的长度（8）——与短标签长度相同，正是空壳病灶的来源。 */
+const SESSION_ID_PREFIX = 'session-'
+
+/**
+ * 会话 id → 8 位显示短标签（剥离 `session-` 前缀后截断）。
+ * @param id - 会话 id（`session-<uuid>` 或其他形状）。
+ * @returns 8 位短标签；空 id 返回空串。
+ */
+export function shortSessionLabel(id: string): string {
+  const bare = id.startsWith(SESSION_ID_PREFIX) ? id.slice(SESSION_ID_PREFIX.length) : id
+  return bare.slice(0, 8)
+}

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -219,6 +219,7 @@ import {
 } from '../commands/registry.js'
 import { PickerController, type PickerItem } from '../picker.js'
 import { formatSessionTabs, type SessionTab } from '../format/session-tabs.js'
+import { shortSessionLabel } from '../session-label.js'
 import { accumulateUsage, formatSessionCostReport, type SessionCostBucket } from '../format/session-cost.js'
 import { renderTranscript, parseToolArguments, toolResultText, type RenderedRow } from './render.js'
 import { CommandPalette } from '../command-palette.js'
@@ -1471,7 +1472,9 @@ export class TuiApp {
    * live store 没有时走 switchSession → resume。
    */
   private async restoreRecentOtherSession(): Promise<void> {
-    const others = (await listSessions(this.ctx)).filter(s => s.id !== this.activeSessionId)
+    // listSessions 失败静默降级（与 refreshSessionTabs 的 catch 对称）：
+    // 调用点为 void 触发（Ctrl+S），无 catch 会成为 unhandled rejection。
+    const others = (await listSessions(this.ctx).catch(() => [])).filter(s => s.id !== this.activeSessionId)
     const target = others[0]?.id
     if (target !== undefined) await this.switchSession(target)
   }
@@ -2179,9 +2182,9 @@ export class TuiApp {
    */
   private subagentLabel(id: string): string {
     for (const e of this.delegationEntries ?? []) {
-      if (e.kind === 'child' && e.id === id) return e.label ?? id.slice(0, 8)
+      if (e.kind === 'child' && e.id === id) return e.label ?? shortSessionLabel(id)
     }
-    return id.slice(0, 8)
+    return shortSessionLabel(id)
   }
 
   private refreshDelegationTree(sessionId: SessionId): void {
@@ -2192,9 +2195,11 @@ export class TuiApp {
       this.delegationEntries = entries
       this.renderBatcher.schedule()
     }).catch(() => {
-      /* v8 ignore next -- dispose 后 reject 的竞态守卫（同步测试无法构造） */
+      // 非 dispose 原因的失败同样要重绘（置空清面板），否则滞留旧树直到
+      // 120ms ticker 自愈；与 then 分支对称调度。
       if (this.disposed) return
       this.delegationEntries = null
+      this.renderBatcher.schedule()
     })
   }
 

--- a/tests/delegation-panel.spec.ts
+++ b/tests/delegation-panel.spec.ts
@@ -92,6 +92,16 @@ describe('projectDelegationTree label 与短哈希回退', () => {
     expect(rows.some(r => r.includes('aaaaaaaa'))).toBe(true)
     expect(rows.some(r => r.includes('aaaaaaaa-bbbb'))).toBe(false)
   })
+
+  it('session- 前缀 id 的短哈希回退去前缀（uuid8，非 session- 空壳）', () => {
+    const entry: DelegationTreeEntry = {
+      ...childInactiveOneShotNoLabel,
+      id: 'session-77aa88bb-9c00-4d11-8e22-334455667788',
+    }
+    const rows = projectDelegationTree([entry], new Map(), new Map(), { width: 80 })
+    expect(rows.some(r => r.includes('77aa88bb'))).toBe(true)
+    expect(rows.some(r => r.includes('session-'))).toBe(false)
+  })
 })
 
 describe('projectDelegationTree identities 投影覆盖', () => {

--- a/tests/question-panel.spec.ts
+++ b/tests/question-panel.spec.ts
@@ -8,9 +8,20 @@
  * 以 packages/interaction/user-interaction/src/types.ts 实测为准（intent 唯一
  * kind 'plan-review' 带 approve: string；multiSelect 缺省单选）。
  */
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { resetTermCapsCache } from '../src/term-caps.js'
+import { pinTuiEnvBaseline } from './env-baseline.ts'
 import { projectQuestionPanel, type QuestionItemInput } from '../src/question-panel.js'
 import { displayWidth } from '../src/width.js'
+
+// 环境基线：面板字形接 useAsciiGlyphs 后，测试进程（非 TTY，chalk.level<3）
+// 恒为 ASCII 档——本 spec 的 Unicode 断言统一在 pin 基线之上固定 '0' 覆盖，
+// 降级用例在测试体内自行切 '1'。
+pinTuiEnvBaseline()
+beforeEach(() => {
+  process.env.RIVET_ASCII_UI = '0'
+  resetTermCapsCache()
+})
 
 const BOLD = '\x1B[1m'
 const RESET = '\x1B[0m'
@@ -216,5 +227,25 @@ describe('窄宽截断', () => {
     const rows = projectQuestionPanel({ questions: [plainSingle] }, { width: 80 })
     expect(rows).toContain('❓ 请选择发布策略')
     expect(rows).toContain('  1. 金丝雀发布')
+  })
+})
+
+describe('legacy conhost ASCII 降级（RIVET_ASCII_UI=1）', () => {
+  it('❓/🧭/✓/✗ 全部降级为 ?/>/+/x（GBK conhost 不出豆腐）', () => {
+    process.env.RIVET_ASCII_UI = '1'
+    resetTermCapsCache()
+    const rows = projectQuestionPanel({ questions: [planReview, plainSingle] }, { width: 80 })
+    const text = rows.join('\n')
+    expect(text).toContain('? 提问')
+    expect(text).toContain('> 评审以下计划')
+    expect(text).toContain('+ 1. 批准')
+    expect(text).toContain('x 2. 修改后重提')
+    expect(text).toContain('? 请选择发布策略')
+    expect(text).not.toContain('❓')
+    expect(text).not.toContain('🧭')
+    expect(text).not.toContain('✓')
+    expect(text).not.toContain('✗')
+    process.env.RIVET_ASCII_UI = '0'
+    resetTermCapsCache()
   })
 })

--- a/tests/restore-session.spec.ts
+++ b/tests/restore-session.spec.ts
@@ -102,6 +102,21 @@ describe('formatRestorableSessions — 展示行', () => {
     expect(formatRestorableSessions([row], { now: NOW })).toEqual(['● 刚刚 · #s-x'])
   })
 
+  it('session- 前缀 id → 短 id 去前缀（#uuid8；id 与 fork 父 id 均不出现 #session- 空壳）', () => {
+    const row: RestorableSession = {
+      id: 'session-3f2a1b9c-4d5e-4f60-8a7b-9c0d1e2f3a4b' as SessionId,
+      createdAt: NOW - 1000,
+      cwd: undefined,
+      parentSession: 'session-01234567-89ab-4cde-8f01-23456789012a' as SessionId,
+      live: false,
+      agentPreset: undefined,
+    }
+    const lines = formatRestorableSessions([row], { now: NOW })
+    expect(lines[0]).toContain('#3f2a1b9c')
+    expect(lines[0]).toContain('fork #01234567')
+    expect(lines[0]).not.toContain('#session-')
+  })
+
   it('persisted 行无 parentSession → 不渲染 fork 段', () => {
     const row: RestorableSession = { id: 's-y' as SessionId, createdAt: NOW - 1000, cwd: undefined, parentSession: undefined, agentPreset: undefined, live: false }
     expect(formatRestorableSessions([row], { now: NOW })).toEqual(['○ 刚刚 · #s-y'])


### PR DESCRIPTION
Companion to #37 — covers the same `session-` shell-label defect at the **remaining** shortening sites (this PR intentionally does not touch the two tab-label sites in `app.ts` that #37 already fixes, so the two PRs merge cleanly).

## Problem

`SessionId` is shaped `session-<uuid>`; the prefix is exactly 8 characters, so every `id.slice(0, 8)` produces the constant shell `session-`:

| Site | Symptom |
|---|---|
| `restore-session.ts` `shortId` | welcome-page restorable list shows `#session-` (session id **and** fork parent id) |
| `delegation-panel.ts` `shortHash` | child rows collapse to `session-` when no label |
| `app.ts` `subagentLabel` | conversation subagent rows show `session-` on cache miss |

Plus three quiet-failure defects (same as the sibling repo's fixes):

1. `restoreRecentOtherSession` (Ctrl+S) — `listSessions` rejection surfaces as an unhandled rejection (the caller is `void`); no UI feedback. `refreshSessionTabs` right below already does `.catch(() => [])`.
2. `refreshDelegationTree` — the `catch` branch clears the cache but never schedules a repaint, so a failed refresh leaves the stale tree until the 120ms ticker heals it.
3. `question-panel.ts` — the `❓`/`🧭` emoji and `✓`/`✗` marks are hardcoded and render as tofu on GBK legacy conhost; every other decorative surface already routes through `useAsciiGlyphs`.

## Fix

- New shared `src/session-label.ts` — `shortSessionLabel(id)`: strip the `session-` prefix, then take 8 chars (other id shapes unchanged). Used at all three sites above.
- `listSessions(this.ctx).catch(() => [])` in `restoreRecentOtherSession`.
- `renderBatcher.schedule()` added to the delegation-tree catch branch.
- `questionGlyphs()` tier pair (`❓/🧭/✓/✗` ↔ `?/>/+/x`) selected by `useAsciiGlyphs()`; Unicode tier unchanged. The spec pins `RIVET_ASCII_UI='0'` above `pinTuiEnvBaseline` (non-TTY test processes would otherwise always select the ASCII tier).
- `lib/index.js` **synced** — this repo tracks the built artifact.

## Verification (RED → GREEN)

- RED first: 3 failing cases (restore-session `session-<uuid>` → `#3f2a1b9c` / `fork #01234567`; delegation-panel fallback; `RIVET_ASCII_UI=1` glyph tier).
- GREEN: `vitest run` = **1898/1898** (105 files; baseline 1895 + 3 new); `npm run typecheck` clean; `npm run build` artifact contains `shortSessionLabel` at all consumption sites.
