### PR TITLE
fix(ui): persist theme selection and rerender history

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { Service } from "@deepseek-ai/cordis";
 import { execFile, execFileSync, spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
@@ -16,6 +17,814 @@ import { createUserMessage } from "@deepseek-ai/dsh-llm";
 import { structuredPatch } from "diff";
 import { collectSessionTitleMessages, fallbackSessionTitle, foldSessionTitle } from "@deepseek-ai/dsh-session-title";
 import { UserQuestionError } from "@deepseek-ai/dsh-user-questions";
+//#region node_modules/@deepseek-ai/cosmokit/lib/index.js
+/** Return true when a value is `null` or `undefined`. */
+function isNullable(value) {
+	return value === null || value === void 0;
+}
+/** Return true for non-array object values. */
+function isPlainObject$1(data) {
+	return data && typeof data === "object" && !Array.isArray(data);
+}
+/** Filter object entries and return a new object. */
+function filterKeys(object, filter) {
+	return Object.fromEntries(Object.entries(object).filter(([key, value]) => filter(key, value)));
+}
+/** Map object values while preserving the original key set. */
+function mapValues(object, transform) {
+	return Object.fromEntries(Object.entries(object).map(([key, value]) => [key, transform(value, key)]));
+}
+/** Pick selected keys from an object, optionally including `undefined` values. */
+function pick(source, keys, forced) {
+	if (!keys) return { ...source };
+	const result = {};
+	for (const key of keys) if (forced || source[key] !== void 0) result[key] = source[key];
+	return result;
+}
+/** Test values using `instanceof` with a `toStringTag` fallback. */
+function is(type, value) {
+	if (arguments.length === 1) return (value) => is(type, value);
+	return type in globalThis && value instanceof globalThis[type] || Object.prototype.toString.call(value).slice(8, -1) === type;
+}
+function isArrayBufferLike(value) {
+	return is("ArrayBuffer", value) || is("SharedArrayBuffer", value);
+}
+function isArrayBufferSource(value) {
+	return isArrayBufferLike(value) || ArrayBuffer.isView(value);
+}
+/** Binary source detection and base64/hex conversion helpers. */
+var Binary;
+(function(Binary) {
+	Binary.is = isArrayBufferLike;
+	Binary.isSource = isArrayBufferSource;
+	function fromSource(source) {
+		if (ArrayBuffer.isView(source)) return source.buffer.slice(source.byteOffset, source.byteOffset + source.byteLength);
+		else return source;
+	}
+	Binary.fromSource = fromSource;
+	function toBase64(source) {
+		source = fromSource(source);
+		if (typeof Buffer !== "undefined") return Buffer.from(source).toString("base64");
+		let binary = "";
+		const bytes = new Uint8Array(source);
+		for (let i = 0; i < bytes.byteLength; i++) binary += String.fromCharCode(bytes[i]);
+		return btoa(binary);
+	}
+	Binary.toBase64 = toBase64;
+	function fromBase64(source) {
+		if (typeof Buffer !== "undefined") return fromSource(Buffer.from(source, "base64"));
+		return Uint8Array.from(atob(source), (c) => c.charCodeAt(0));
+	}
+	Binary.fromBase64 = fromBase64;
+	function toHex(source) {
+		source = fromSource(source);
+		if (typeof Buffer !== "undefined") return Buffer.from(source).toString("hex");
+		return Array.from(new Uint8Array(source), (byte) => byte.toString(16).padStart(2, "0")).join("");
+	}
+	Binary.toHex = toHex;
+	function fromHex(source) {
+		if (typeof Buffer !== "undefined") return fromSource(Buffer.from(source, "hex"));
+		const hex = source.length % 2 === 0 ? source : source.slice(0, source.length - 1);
+		const buffer = [];
+		for (let i = 0; i < hex.length; i += 2) buffer.push(parseInt(`${hex[i]}${hex[i + 1]}`, 16));
+		return Uint8Array.from(buffer).buffer;
+	}
+	Binary.fromHex = fromHex;
+})(Binary || (Binary = {}));
+Binary.fromBase64;
+Binary.toBase64;
+Binary.fromHex;
+Binary.toHex;
+/** Deep-clone common JavaScript values while preserving prototypes and cycles. */
+function clone(source, refs = /* @__PURE__ */ new Map()) {
+	if (!source || typeof source !== "object") return source;
+	if (is("Date", source)) return new Date(source.valueOf());
+	if (is("RegExp", source)) return new RegExp(source.source, source.flags);
+	if (isArrayBufferLike(source)) return source.slice(0);
+	if (ArrayBuffer.isView(source)) return source.buffer.slice(source.byteOffset, source.byteOffset + source.byteLength);
+	const cached = refs.get(source);
+	if (cached) return cached;
+	if (Array.isArray(source)) {
+		const result = [];
+		refs.set(source, result);
+		source.forEach((value, index) => {
+			result[index] = Reflect.apply(clone, null, [value, refs]);
+		});
+		return result;
+	}
+	const result = Object.create(Object.getPrototypeOf(source));
+	refs.set(source, result);
+	for (const key of Reflect.ownKeys(source)) {
+		const descriptor = { ...Reflect.getOwnPropertyDescriptor(source, key) };
+		if ("value" in descriptor) descriptor.value = Reflect.apply(clone, null, [descriptor.value, refs]);
+		Reflect.defineProperty(result, key, descriptor);
+	}
+	return result;
+}
+/** Deeply compare arrays, dates, regexps, buffers, and plain object fields. */
+function deepEqual(a, b, strict) {
+	if (a === b) return true;
+	if (!strict && isNullable(a) && isNullable(b)) return true;
+	if (typeof a !== typeof b) return false;
+	if (typeof a !== "object") return false;
+	if (!a || !b) return false;
+	function check(test, then) {
+		return test(a) ? test(b) ? then(a, b) : false : test(b) ? false : void 0;
+	}
+	return check(Array.isArray, (a, b) => a.length === b.length && a.every((item, index) => deepEqual(item, b[index]))) ?? check(is("Date"), (a, b) => a.valueOf() === b.valueOf()) ?? check(is("RegExp"), (a, b) => a.source === b.source && a.flags === b.flags) ?? check(isArrayBufferLike, (a, b) => {
+		if (a.byteLength !== b.byteLength) return false;
+		const viewA = new Uint8Array(a);
+		const viewB = new Uint8Array(b);
+		for (let i = 0; i < viewA.length; i++) if (viewA[i] !== viewB[i]) return false;
+		return true;
+	}) ?? Object.keys({
+		...a,
+		...b
+	}).every((key) => deepEqual(a[key], b[key], strict));
+}
+/** Time constants plus parsing and formatting helpers. */
+var Time;
+(function(Time) {
+	Time.millisecond = 1;
+	Time.second = 1e3;
+	Time.minute = Time.second * 60;
+	Time.hour = Time.minute * 60;
+	Time.day = Time.hour * 24;
+	Time.week = Time.day * 7;
+	let timezoneOffset = (/* @__PURE__ */ new Date()).getTimezoneOffset();
+	function setTimezoneOffset(offset) {
+		timezoneOffset = offset;
+	}
+	Time.setTimezoneOffset = setTimezoneOffset;
+	function getTimezoneOffset() {
+		return timezoneOffset;
+	}
+	Time.getTimezoneOffset = getTimezoneOffset;
+	function getDateNumber(date = /* @__PURE__ */ new Date(), offset) {
+		if (typeof date === "number") date = new Date(date);
+		if (offset === void 0) offset = timezoneOffset;
+		return Math.floor((date.valueOf() / Time.minute - offset) / 1440);
+	}
+	Time.getDateNumber = getDateNumber;
+	function fromDateNumber(value, offset) {
+		const date = new Date(value * Time.day);
+		if (offset === void 0) offset = timezoneOffset;
+		return new Date(+date + offset * Time.minute);
+	}
+	Time.fromDateNumber = fromDateNumber;
+	const numeric = /\d+(?:\.\d+)?/.source;
+	const timeRegExp = new RegExp(`^${[
+		"w(?:eek(?:s)?)?",
+		"d(?:ay(?:s)?)?",
+		"h(?:our(?:s)?)?",
+		"m(?:in(?:ute)?(?:s)?)?",
+		"s(?:ec(?:ond)?(?:s)?)?"
+	].map((unit) => `(${numeric}${unit})?`).join("")}$`);
+	function parseTime(source) {
+		const capture = timeRegExp.exec(source);
+		if (!capture) return 0;
+		return (parseFloat(capture[1]) * Time.week || 0) + (parseFloat(capture[2]) * Time.day || 0) + (parseFloat(capture[3]) * Time.hour || 0) + (parseFloat(capture[4]) * Time.minute || 0) + (parseFloat(capture[5]) * Time.second || 0);
+	}
+	Time.parseTime = parseTime;
+	function parseDate(date) {
+		const parsed = parseTime(date);
+		if (parsed) date = Date.now() + parsed;
+		else if (/^\d{1,2}(:\d{1,2}){1,2}$/.test(date)) date = `${(/* @__PURE__ */ new Date()).toLocaleDateString()}-${date}`;
+		else if (/^\d{1,2}-\d{1,2}-\d{1,2}(:\d{1,2}){1,2}$/.test(date)) date = `${(/* @__PURE__ */ new Date()).getFullYear()}-${date}`;
+		return date ? new Date(date) : /* @__PURE__ */ new Date();
+	}
+	Time.parseDate = parseDate;
+	function format(ms) {
+		const abs = Math.abs(ms);
+		if (abs >= Time.day - Time.hour / 2) return Math.round(ms / Time.day) + "d";
+		else if (abs >= Time.hour - Time.minute / 2) return Math.round(ms / Time.hour) + "h";
+		else if (abs >= Time.minute - Time.second / 2) return Math.round(ms / Time.minute) + "m";
+		else if (abs >= Time.second) return Math.round(ms / Time.second) + "s";
+		return ms + "ms";
+	}
+	Time.format = format;
+	function toDigits(source, length = 2) {
+		return source.toString().padStart(length, "0");
+	}
+	Time.toDigits = toDigits;
+	function template(template, time = /* @__PURE__ */ new Date()) {
+		return template.replace("yyyy", time.getFullYear().toString()).replace("yy", time.getFullYear().toString().slice(2)).replace("MM", toDigits(time.getMonth() + 1)).replace("dd", toDigits(time.getDate())).replace("hh", toDigits(time.getHours())).replace("mm", toDigits(time.getMinutes())).replace("ss", toDigits(time.getSeconds())).replace("SSS", toDigits(time.getMilliseconds(), 3));
+	}
+	Time.template = template;
+})(Time || (Time = {}));
+//#endregion
+//#region node_modules/@deepseek-ai/schemastery/lib/index.mjs
+const kSchema = Symbol.for("schemastery");
+const kValidationError = Symbol.for("ValidationError");
+globalThis.__schemastery_index__ ??= 0;
+globalThis.__schemastery_refs__ = void 0;
+var ValidationError = class extends TypeError {
+	options;
+	name = "ValidationError";
+	constructor(message, options) {
+		let prefix = "$";
+		for (const segment of options.path || []) if (typeof segment === "string") prefix += "." + segment;
+		else if (typeof segment === "number") prefix += "[" + segment + "]";
+		else if (typeof segment === "symbol") prefix += `[Symbol(${segment.toString()})]`;
+		if (prefix.startsWith(".")) prefix = prefix.slice(1);
+		super((prefix === "$" ? "" : `${prefix} `) + message);
+		this.options = options;
+	}
+	static is(error) {
+		return !!error?.[kValidationError];
+	}
+};
+Object.defineProperty(ValidationError.prototype, kValidationError, { value: true });
+const Schema = function(options) {
+	const schema = function(data, options = {}) {
+		return Schema.resolve(data, schema, options)[0];
+	};
+	if (options.refs) {
+		const refs = mapValues(options.refs, (options) => new Schema(options));
+		const getRef = (uid) => refs[uid];
+		for (const key in refs) {
+			const options = refs[key];
+			options.sKey = getRef(options.sKey);
+			options.inner = getRef(options.inner);
+			options.list = options.list && options.list.map(getRef);
+			options.dict = options.dict && mapValues(options.dict, getRef);
+		}
+		return refs[options.uid];
+	}
+	Object.assign(schema, options);
+	if (typeof schema.callback === "string") try {
+		schema.callback = new Function("return " + schema.callback)();
+	} catch {}
+	Object.defineProperty(schema, "uid", { value: globalThis.__schemastery_index__++ });
+	Object.setPrototypeOf(schema, Schema.prototype);
+	schema.meta ||= {};
+	schema.toString = schema.toString.bind(schema);
+	return schema;
+};
+Schema.prototype = Object.create(Function.prototype);
+Schema.prototype[kSchema] = true;
+Object.defineProperty(Schema.prototype, "~standard", { get() {
+	return {
+		version: 1,
+		vendor: "schemastery",
+		validate: (value) => {
+			try {
+				return { value: Schema.resolve(value, this, {})[0] };
+			} catch (error) {
+				if (ValidationError.is(error)) return { issues: [{
+					message: error.message,
+					path: error.options.path
+				}] };
+				throw error;
+			}
+		}
+	};
+} });
+Schema.ValidationError = ValidationError;
+Schema.prototype.toJSON = function toJSON() {
+	if (globalThis.__schemastery_refs__) {
+		globalThis.__schemastery_refs__[this.uid] ??= JSON.parse(JSON.stringify({ ...this }));
+		return this.uid;
+	}
+	globalThis.__schemastery_refs__ = { [this.uid]: { ...this } };
+	globalThis.__schemastery_refs__[this.uid] = JSON.parse(JSON.stringify({ ...this }));
+	const result = {
+		uid: this.uid,
+		refs: globalThis.__schemastery_refs__
+	};
+	globalThis.__schemastery_refs__ = void 0;
+	return result;
+};
+Schema.prototype.set = function set(key, value) {
+	this.dict[key] = value;
+	return this;
+};
+Schema.prototype.push = function push(value) {
+	this.list.push(value);
+	return this;
+};
+function mergeDesc(original, messages) {
+	const result = typeof original === "string" ? { "": original } : { ...original };
+	for (const locale in messages) {
+		const value = messages[locale];
+		if (value?.$description || value?.$desc) result[locale] = value.$description || value.$desc;
+		else if (typeof value === "string") result[locale] = value;
+	}
+	return result;
+}
+function getInner(value) {
+	return value?.$value ?? value?.$inner;
+}
+function extractKeys(data) {
+	return filterKeys(data ?? {}, (key) => !key.startsWith("$"));
+}
+Schema.prototype.i18n = function i18n(messages) {
+	const schema = Schema(this);
+	const desc = mergeDesc(schema.meta.description, messages);
+	if (Object.keys(desc).length) schema.meta.description = desc;
+	if (schema.dict) schema.dict = mapValues(schema.dict, (inner, key) => {
+		return inner.i18n(mapValues(messages, (data) => getInner(data)?.[key] ?? data?.[key]));
+	});
+	if (schema.list) schema.list = schema.list.map((inner, index) => {
+		return inner.i18n(mapValues(messages, (data = {}) => {
+			if (Array.isArray(getInner(data))) return getInner(data)[index];
+			if (Array.isArray(data)) return data[index];
+			return extractKeys(data);
+		}));
+	});
+	if (schema.inner) schema.inner = schema.inner.i18n(mapValues(messages, (data) => {
+		if (getInner(data)) return getInner(data);
+		return extractKeys(data);
+	}));
+	if (schema.sKey) schema.sKey = schema.sKey.i18n(mapValues(messages, (data) => data?.$key));
+	return schema;
+};
+Schema.prototype.extra = function extra(key, value) {
+	const schema = Schema(this);
+	schema.meta = {
+		...schema.meta,
+		[key]: value
+	};
+	return schema;
+};
+for (const key of [
+	"required",
+	"disabled",
+	"collapse",
+	"hidden",
+	"loose"
+]) Object.assign(Schema.prototype, { [key](value = true) {
+	const schema = Schema(this);
+	schema.meta = {
+		...schema.meta,
+		[key]: value
+	};
+	return schema;
+} });
+Schema.prototype.deprecated = function deprecated() {
+	const schema = Schema(this);
+	schema.meta.badges ||= [];
+	schema.meta.badges.push({
+		text: "deprecated",
+		type: "danger"
+	});
+	return schema;
+};
+Schema.prototype.experimental = function experimental() {
+	const schema = Schema(this);
+	schema.meta.badges ||= [];
+	schema.meta.badges.push({
+		text: "experimental",
+		type: "warning"
+	});
+	return schema;
+};
+Schema.prototype.pattern = function pattern(regexp) {
+	const schema = Schema(this);
+	const pattern = pick(regexp, ["source", "flags"]);
+	schema.meta = {
+		...schema.meta,
+		pattern
+	};
+	return schema;
+};
+Schema.prototype.simplify = function simplify(value) {
+	if (deepEqual(value, this.meta.default, this.type === "dict")) return null;
+	if (isNullable(value)) return value;
+	if (this.type === "object" || this.type === "dict") {
+		const result = {};
+		for (const key in value) {
+			const item = (this.type === "object" ? this.dict[key] : this.inner)?.simplify(value[key]);
+			if (this.type === "dict" || !isNullable(item)) result[key] = item;
+		}
+		if (deepEqual(result, this.meta.default, this.type === "dict")) return null;
+		return result;
+	} else if (this.type === "array" || this.type === "tuple") {
+		const result = [];
+		value.forEach((value, index) => {
+			const schema = this.type === "array" ? this.inner : this.list[index];
+			const item = schema ? schema.simplify(value) : value;
+			result.push(item);
+		});
+		return result;
+	} else if (this.type === "intersect") {
+		const result = {};
+		for (const item of this.list) Object.assign(result, item.simplify(value));
+		return result;
+	} else if (this.type === "union") for (const schema of this.list) try {
+		Schema.resolve(value, schema, {});
+		return schema.simplify(value);
+	} catch {}
+	return value;
+};
+Schema.prototype.toString = function toString(inline) {
+	return formatters[this.type]?.(this, inline) ?? `Schema<${this.type}>`;
+};
+Schema.prototype.role = function role(role, extra) {
+	const schema = Schema(this);
+	schema.meta = {
+		...schema.meta,
+		role,
+		extra
+	};
+	return schema;
+};
+for (const key of [
+	"default",
+	"link",
+	"comment",
+	"description",
+	"max",
+	"min",
+	"step"
+]) Object.assign(Schema.prototype, { [key](value) {
+	const schema = Schema(this);
+	schema.meta = {
+		...schema.meta,
+		[key]: value
+	};
+	return schema;
+} });
+const resolvers = {};
+Schema.extend = function extend(type, resolve) {
+	resolvers[type] = resolve;
+};
+Schema.resolve = function resolve(data, schema, options = {}, strict = false) {
+	if (!schema) return [data];
+	if (options.ignore?.(data, schema)) return [data];
+	if (isNullable(data) && schema.type !== "lazy") {
+		if (schema.meta.required) throw new ValidationError(`missing required value`, options);
+		let current = schema;
+		let fallback = schema.meta.default;
+		while (current?.type === "intersect" && isNullable(fallback)) {
+			current = current.list[0];
+			fallback = current?.meta.default;
+		}
+		if (isNullable(fallback)) return [data];
+		data = clone(fallback);
+	}
+	const callback = resolvers[schema.type];
+	if (!callback) throw new ValidationError(`unsupported type "${schema.type}"`, options);
+	try {
+		return callback(data, schema, options, strict);
+	} catch (error) {
+		if (!schema.meta.loose) throw error;
+		return [schema.meta.default];
+	}
+};
+Schema.from = function from(source) {
+	if (isNullable(source)) return Schema.any();
+	else if ([
+		"string",
+		"number",
+		"boolean"
+	].includes(typeof source)) return Schema.const(source).required();
+	else if (source[kSchema]) return source;
+	else if (typeof source === "function") switch (source) {
+		case String: return Schema.string().required();
+		case Number: return Schema.number().required();
+		case Boolean: return Schema.boolean().required();
+		case Function: return Schema.function().required();
+		default: return Schema.is(source).required();
+	}
+	else throw new TypeError(`cannot infer schema from ${source}`);
+};
+Schema.lazy = function lazy(builder) {
+	const toJSON = () => {
+		if (!schema.inner[kSchema]) {
+			schema.inner = schema.builder();
+			schema.inner.meta = {
+				...schema.meta,
+				...schema.inner.meta
+			};
+		}
+		return schema.inner.toJSON();
+	};
+	const schema = new Schema({
+		type: "lazy",
+		builder,
+		inner: { toJSON }
+	});
+	return schema;
+};
+Schema.natural = function natural() {
+	return Schema.number().step(1).min(0);
+};
+Schema.percent = function percent() {
+	return Schema.number().step(.01).min(0).max(1).role("slider");
+};
+Schema.date = function date() {
+	return Schema.union([Schema.is(Date), Schema.transform(Schema.string().role("datetime"), (value, options) => {
+		const date = new Date(value);
+		if (isNaN(+date)) throw new ValidationError(`invalid date "${value}"`, options);
+		return date;
+	}, true)]);
+};
+Schema.regExp = function regExp(flag = "") {
+	return Schema.union([Schema.is(RegExp), Schema.transform(Schema.string().role("regexp", { flag }), (value, options) => {
+		try {
+			return new RegExp(value, flag);
+		} catch (e) {
+			throw new ValidationError(e.message, options);
+		}
+	}, true)]);
+};
+Schema.arrayBuffer = function arrayBuffer(encoding) {
+	return Schema.union([
+		Schema.is(ArrayBuffer),
+		Schema.is(SharedArrayBuffer),
+		Schema.transform(Schema.any(), (value, options) => {
+			if (Binary.isSource(value)) return Binary.fromSource(value);
+			throw new ValidationError(`expected ArrayBufferSource but got ${value}`, options);
+		}, true),
+		...encoding ? [Schema.transform(Schema.string(), (value, options) => {
+			try {
+				return encoding === "base64" ? Binary.fromBase64(value) : Binary.fromHex(value);
+			} catch (e) {
+				throw new ValidationError(e.message, options);
+			}
+		}, true)] : []
+	]);
+};
+Schema.extend("lazy", (data, schema, options, strict) => {
+	if (!schema.inner[kSchema]) {
+		schema.inner = schema.builder();
+		schema.inner.meta = {
+			...schema.meta,
+			...schema.inner.meta
+		};
+	}
+	return Schema.resolve(data, schema.inner, options, strict);
+});
+Schema.extend("any", (data) => {
+	return [data];
+});
+Schema.extend("never", (data, _, options) => {
+	throw new ValidationError(`expected nullable but got ${data}`, options);
+});
+Schema.extend("const", (data, { value }, options) => {
+	if (deepEqual(data, value)) return [value];
+	throw new ValidationError(`expected ${value} but got ${data}`, options);
+});
+function checkWithinRange(data, meta, description, options, skipMin = false) {
+	const { max = Infinity, min = -Infinity } = meta;
+	if (data > max) throw new ValidationError(`expected ${description} <= ${max} but got ${data}`, options);
+	if (data < min && !skipMin) throw new ValidationError(`expected ${description} >= ${min} but got ${data}`, options);
+}
+Schema.extend("string", (data, { meta }, options) => {
+	if (typeof data !== "string") throw new ValidationError(`expected string but got ${data}`, options);
+	if (meta.pattern) {
+		const regexp = new RegExp(meta.pattern.source, meta.pattern.flags);
+		if (!regexp.test(data)) throw new ValidationError(`expect string to match regexp ${regexp}`, options);
+	}
+	checkWithinRange(data.length, meta, "string length", options);
+	return [data];
+});
+function decimalShift(data, digits) {
+	const str = data.toString();
+	if (str.includes("e")) return data * Math.pow(10, digits);
+	const index = str.indexOf(".");
+	if (index === -1) return data * Math.pow(10, digits);
+	const frac = str.slice(index + 1);
+	const integer = str.slice(0, index);
+	if (frac.length <= digits) return +(integer + frac.padEnd(digits, "0"));
+	return +(integer + frac.slice(0, digits) + "." + frac.slice(digits));
+}
+function isMultipleOf(data, min, step) {
+	step = Math.abs(step);
+	if (!/^\d+\.\d+$/.test(step.toString())) return (data - min) % step === 0;
+	const index = step.toString().indexOf(".");
+	const digits = step.toString().slice(index + 1).length;
+	return Math.abs(decimalShift(data, digits) - decimalShift(min, digits)) % decimalShift(step, digits) === 0;
+}
+Schema.extend("number", (data, { meta }, options) => {
+	if (typeof data !== "number") throw new ValidationError(`expected number but got ${data}`, options);
+	checkWithinRange(data, meta, "number", options);
+	const { step } = meta;
+	if (step && !isMultipleOf(data, meta.min ?? 0, step)) throw new ValidationError(`expected number multiple of ${step} but got ${data}`, options);
+	return [data];
+});
+Schema.extend("boolean", (data, _, options) => {
+	if (typeof data === "boolean") return [data];
+	throw new ValidationError(`expected boolean but got ${data}`, options);
+});
+Schema.extend("bitset", (data, { bits, meta }, options) => {
+	let value = 0, keys = [];
+	if (typeof data === "number") {
+		value = data;
+		for (const key in bits) if (data & bits[key]) keys.push(key);
+	} else if (Array.isArray(data)) {
+		keys = data;
+		for (const key of keys) {
+			if (typeof key !== "string") throw new ValidationError(`expected string but got ${key}`, options);
+			if (key in bits) value |= bits[key];
+		}
+	} else throw new ValidationError(`expected number or array but got ${data}`, options);
+	if (value === meta.default) return [value];
+	return [value, keys];
+});
+Schema.extend("function", (data, _, options) => {
+	if (typeof data === "function") return [data];
+	throw new ValidationError(`expected function but got ${data}`, options);
+});
+Schema.extend("is", (data, { constructor }, options) => {
+	if (typeof constructor === "function") {
+		if (data instanceof constructor) return [data];
+		throw new ValidationError(`expected ${constructor.name} but got ${data}`, options);
+	} else {
+		if (isNullable(data)) throw new ValidationError(`expected ${constructor} but got ${data}`, options);
+		let prototype = Object.getPrototypeOf(data);
+		while (prototype) {
+			if (prototype.constructor?.name === constructor) return [data];
+			prototype = Object.getPrototypeOf(prototype);
+		}
+		throw new ValidationError(`expected ${constructor} but got ${data}`, options);
+	}
+});
+function property(data, key, schema, options) {
+	try {
+		const [value, adapted] = Schema.resolve(data[key], schema, {
+			...options,
+			path: [...options.path || [], key]
+		});
+		if (adapted !== void 0) data[key] = adapted;
+		return value;
+	} catch (e) {
+		if (!options?.autofix) throw e;
+		delete data[key];
+		return schema.meta.default;
+	}
+}
+Schema.extend("array", (data, { inner, meta }, options) => {
+	if (!Array.isArray(data)) throw new ValidationError(`expected array but got ${data}`, options);
+	checkWithinRange(data.length, meta, "array length", options, !isNullable(inner.meta.default));
+	return [data.map((_, index) => property(data, index, inner, options))];
+});
+Schema.extend("dict", (data, { inner, sKey }, options, strict) => {
+	if (!isPlainObject$1(data)) throw new ValidationError(`expected object but got ${data}`, options);
+	const result = {};
+	for (const key in data) {
+		let rKey;
+		try {
+			rKey = Schema.resolve(key, sKey, options)[0];
+		} catch (error) {
+			if (strict) continue;
+			throw error;
+		}
+		result[rKey] = property(data, key, inner, options);
+		data[rKey] = data[key];
+		if (key !== rKey) delete data[key];
+	}
+	return [result];
+});
+Schema.extend("tuple", (data, { list }, options, strict) => {
+	if (!Array.isArray(data)) throw new ValidationError(`expected array but got ${data}`, options);
+	const result = list.map((inner, index) => property(data, index, inner, options));
+	if (strict) return [result];
+	result.push(...data.slice(list.length));
+	return [result];
+});
+function merge(result, data) {
+	for (const key in data) {
+		if (key in result) continue;
+		result[key] = data[key];
+	}
+}
+Schema.extend("object", (data, { dict }, options, strict) => {
+	if (!isPlainObject$1(data)) throw new ValidationError(`expected object but got ${data}`, options);
+	const result = {};
+	for (const key in dict) {
+		const value = property(data, key, dict[key], options);
+		if (!isNullable(value) || key in data) result[key] = value;
+	}
+	if (!strict) merge(result, data);
+	return [result];
+});
+Schema.extend("union", (data, { list, toString }, options, strict) => {
+	const messages = [];
+	for (const inner of list) try {
+		return Schema.resolve(data, inner, options, strict);
+	} catch (error) {
+		messages.push(error);
+	}
+	throw new ValidationError(`expected ${toString()} but got ${JSON.stringify(data)}`, options);
+});
+Schema.extend("intersect", (data, { list, toString }, options, strict) => {
+	if (!list.length) return [data];
+	let result;
+	for (const inner of list) {
+		const value = Schema.resolve(data, inner, options, true)[0];
+		if (isNullable(value)) continue;
+		if (isNullable(result)) result = value;
+		else if (typeof result !== typeof value) throw new ValidationError(`expected ${toString()} but got ${JSON.stringify(data)}`, options);
+		else if (typeof value === "object") merge(result ??= {}, value);
+		else if (result !== value) throw new ValidationError(`expected ${toString()} but got ${JSON.stringify(data)}`, options);
+	}
+	if (!strict && isPlainObject$1(data)) merge(result, data);
+	return [result];
+});
+Schema.extend("transform", (data, { inner, callback, preserve }, options) => {
+	const [result, adapted = data] = Schema.resolve(data, inner, options, true);
+	if (preserve) return [callback(result)];
+	else return [callback(result), callback(adapted)];
+});
+const formatters = {};
+function defineMethod(name, keys, format) {
+	formatters[name] = format;
+	Object.assign(Schema, { [name](...args) {
+		const schema = new Schema({ type: name });
+		keys.forEach((key, index) => {
+			switch (key) {
+				case "sKey":
+					schema.sKey = args[index] ?? Schema.string();
+					break;
+				case "inner":
+					schema.inner = Schema.from(args[index]);
+					break;
+				case "list":
+					schema.list = args[index].map(Schema.from);
+					break;
+				case "dict":
+					schema.dict = mapValues(args[index], Schema.from);
+					break;
+				case "bits":
+					schema.bits = {};
+					for (const key in args[index]) {
+						if (typeof args[index][key] !== "number") continue;
+						schema.bits[key] = args[index][key];
+					}
+					break;
+				case "callback": {
+					const callback = schema.callback = args[index];
+					callback["toJSON"] ||= () => callback.toString();
+					break;
+				}
+				case "constructor": {
+					const constructor = schema.constructor = args[index];
+					if (typeof constructor === "function") constructor["toJSON"] ||= () => constructor["name"];
+					break;
+				}
+				default: schema[key] = args[index];
+			}
+		});
+		if (name === "object" || name === "dict") schema.meta.default = {};
+		else if (name === "array" || name === "tuple") schema.meta.default = [];
+		else if (name === "bitset") schema.meta.default = 0;
+		return schema;
+	} });
+}
+defineMethod("is", ["constructor"], ({ constructor }) => {
+	if (typeof constructor === "function") return constructor.name;
+	else return constructor;
+});
+defineMethod("any", [], () => "any");
+defineMethod("never", [], () => "never");
+defineMethod("const", ["value"], ({ value }) => typeof value === "string" ? JSON.stringify(value) : value);
+defineMethod("string", [], () => "string");
+defineMethod("number", [], () => "number");
+defineMethod("boolean", [], () => "boolean");
+defineMethod("bitset", ["bits"], () => "bitset");
+defineMethod("function", [], () => "function");
+defineMethod("array", ["inner"], ({ inner }) => `${inner.toString(true)}[]`);
+defineMethod("dict", ["inner", "sKey"], ({ inner, sKey }) => `{ [key: ${sKey.toString()}]: ${inner.toString()} }`);
+defineMethod("tuple", ["list"], ({ list }) => `[${list.map((inner) => inner.toString()).join(", ")}]`);
+defineMethod("object", ["dict"], ({ dict }) => {
+	if (Object.keys(dict).length === 0) return "{}";
+	return `{ ${Object.entries(dict).map(([key, inner]) => {
+		return `${key}${inner.meta.required ? "" : "?"}: ${inner.toString()}`;
+	}).join(", ")} }`;
+});
+defineMethod("union", ["list"], ({ list }, inline) => {
+	const result = list.map(({ toString: format }) => format()).join(" | ");
+	return inline ? `(${result})` : result;
+});
+defineMethod("intersect", ["list"], ({ list }) => {
+	return `${list.map((inner) => inner.toString(true)).join(" & ")}`;
+});
+defineMethod("transform", [
+	"inner",
+	"callback",
+	"preserve"
+], ({ inner }, isInner) => inner.toString(isInner));
+/**
+* Service Definition for the user-settings capability seam (`ctx.settings`). Providers store one raw document of
+* per-namespace sections; plugins register a namespace schema and read the
+* resolved value, which layers schema defaults, the registrant's composition
+* `base`, and the user document section, in that order.
+* @module @deepseek-ai/dsh-settings
+*/
+const NAMESPACE_PATTERN = /^[a-z][a-z0-9-]*$/;
+/**
+* Brand a raw string as a {@link SettingsNamespace}.
+* @param value - candidate namespace; lowercase kebab-case, as in plugin short names.
+* @returns the branded namespace.
+*/
+function settingsNamespace(value) {
+	if (!NAMESPACE_PATTERN.test(value)) throw new TypeError(`settings namespace "${value}" must match ${String(NAMESPACE_PATTERN)}`);
+	return value;
+}
+Service.init;
+//#endregion
 //#region lib/types/self-update.js
 /**
 * 启动时对照 npm `latest`，把 profile 里的本包升到新版本。
@@ -14602,8 +15411,11 @@ function createBuiltinCommands(deps) {
 					deps.openThemePicker();
 					return;
 				}
-				if (setTheme(name)) echo(`主题已切换: ${name}`);
-				else echo(`未知主题: ${name}。可用: ${THEME_NAMES.join(", ")}`);
+				if (setTheme(name)) {
+					deps.persistTheme?.(name);
+					deps.onThemeChanged?.();
+					echo(`主题已切换: ${name}`);
+				} else echo(`未知主题: ${name}。可用: ${THEME_NAMES.join(", ")}`);
 			}
 		},
 		{
@@ -15601,14 +16413,18 @@ function toolResultText(result) {
 * @returns ANSI 行数组。
 */
 function renderMessageRows(message, theme, columns, options = {}) {
-	if (message.kind === "user") return formatUserMessage({
-		content: message.text,
-		width: columns,
-		timestamp: message.time
-	}, theme).map((ansi) => ({
-		ansi,
-		kind: "user"
-	}));
+	if (message.kind === "user") {
+		const content = stripSystemReminders(message.text);
+		if (content === "") return [];
+		return formatUserMessage({
+			content,
+			width: columns,
+			timestamp: message.time
+		}, theme).map((ansi) => ({
+			ansi,
+			kind: "user"
+		}));
+	}
 	const rows = [];
 	if (message.reasoning !== "") rows.push(...formatReasoningBlock({
 		text: message.reasoning,
@@ -15625,6 +16441,10 @@ function renderMessageRows(message, theme, columns, options = {}) {
 		kind: "assistant"
 	})));
 	return rows;
+}
+/** System reminders are runtime instructions, not conversation content. */
+function stripSystemReminders(text) {
+	return text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/gi, "").replace(/Current runtime context\.[\s\S]*?Approval policy:[\s\S]*?fail(?:s)? closed\.\s*/gi, "").trim();
 }
 /**
 * 渲染一条工具调用（call → result 配对）为卡片行。
@@ -18936,6 +19756,7 @@ var TuiApp = class {
 	ownedHandle = null;
 	initialSessionId;
 	themeName;
+	persistTheme;
 	onExit;
 	onRestart;
 	/** 外部编辑器触发键（Phase 6.4）；缺省 ctrl_e（ctrl+o 已恢复为推理展开）。 */
@@ -19065,6 +19886,7 @@ var TuiApp = class {
 		this.stdin = options.stdin;
 		this.initialSessionId = options.initialSessionId;
 		this.themeName = options.theme ?? "auto";
+		this.persistTheme = options.persistTheme;
 		this.onExit = options.onExit;
 		this.onRestart = options.onRestart;
 		this.editorKey = options.editorKey ?? "ctrl_e";
@@ -19129,6 +19951,12 @@ var TuiApp = class {
 		this.inputController = new InputController();
 		this.slash = new SlashCommandRegistry();
 		for (const command of createBuiltinCommands({
+			persistTheme: (name) => {
+				this.persistTheme?.(name);
+			},
+			onThemeChanged: () => {
+				this.rerenderHistory();
+			},
 			newSession: () => this.newSession(),
 			forkSession: () => this.forkSession(),
 			switchLiveModel: (selection) => this.switchLiveModel(selection),
@@ -19998,10 +20826,7 @@ var TuiApp = class {
 		}));
 		const selectedIndex = Math.max(0, THEME_NAMES.indexOf(prev));
 		picker.open("选择主题", items, (item) => {
-			this.commitToScrollback({
-				text: `主题已切换: ${item.value}`,
-				trailingNewline: true
-			});
+			this.persistTheme?.(item.value);
 		}, selectedIndex, {
 			onPreview: (item) => {
 				setTheme(item.value);
@@ -20248,19 +21073,7 @@ var TuiApp = class {
 		this.lastReasoningBlock = null;
 		this.reasoningExpanded = false;
 		this.pendingCallTitles.clear();
-		const rows = renderTranscript(this.transcript.view, this.theme, this.stdout.columns, {
-			compact: this.compactMode,
-			resolveViews: (tool) => resolveToolViews(this.toolPresenters(), {
-				name: tool.name,
-				argumentsRaw: tool.arguments,
-				...tool.result === void 0 ? {} : { result: {
-					content: tool.result.data.message.content[0].content,
-					isError: toolResultText(tool.result).isError,
-					...tool.result.data.meta === void 0 ? {} : { meta: tool.result.data.meta }
-				} }
-			})
-		});
-		this.commitRows(rows);
+		this.commitRows(this.renderHistoryRows());
 		this.inputLine.setHistory(this.history);
 		this.subagentDisposer?.();
 		this.delegationEntries = null;
@@ -20989,6 +21802,12 @@ var TuiApp = class {
 			} else if (key.name === "return") {
 				picker.commit();
 				this.overlay.deactivate();
+				this.rerenderHistory();
+				this.commitToScrollback({
+					text: `主题已切换: ${getActiveThemeName()}`,
+					trailingNewline: true
+				});
+				this.flushLiveRender();
 			}
 			return;
 		}
@@ -21252,6 +22071,33 @@ var TuiApp = class {
 		this.commitToScrollback({
 			text: buf.join("\n"),
 			trailingNewline: true
+		});
+	}
+	/** 当前主题变化后，清理终端并用最新颜色重放当前会话历史。 */
+	rerenderHistory() {
+		if (this.disposed || this.overlay !== null && this.overlay.activeId() !== null) return;
+		this.reasoningExpanded = false;
+		this.commit.reset();
+		this.live.reset();
+		this.stdout.write(`${ANSI.ERASE_SCREEN}\x1b[3J\x1b[H`);
+		this.commitRows(this.renderHistoryRows());
+		this.flushLiveRender();
+	}
+	/** 生成当前会话历史消息的主题化渲染行。 */
+	renderHistoryRows() {
+		const transcript = this.transcript;
+		if (transcript === null) return [];
+		return renderTranscript(transcript.view, this.theme, this.stdout.columns, {
+			compact: this.compactMode,
+			resolveViews: (tool) => resolveToolViews(this.toolPresenters(), {
+				name: tool.name,
+				argumentsRaw: tool.arguments,
+				...tool.result === void 0 ? {} : { result: {
+					content: tool.result.data.message.content[0].content,
+					isError: toolResultText(tool.result).isError,
+					...tool.result.data.meta === void 0 ? {} : { meta: tool.result.data.meta }
+				} }
+			})
 		});
 	}
 	/**
@@ -22198,6 +23044,8 @@ function uiGlyphs() {
 */
 /** Stable Cordis plugin name the bundle patch inserts. */
 const name = "tui-runner";
+const TUI_SETTINGS_NAMESPACE = settingsNamespace("tui-runner");
+const TUI_SETTINGS_SCHEMA = Schema.object({ theme: Schema.string().default("auto") });
 /**
 * Mount the terminal UI runner.
 * @param ctx - plugin context; the render core wires its services here.
@@ -22215,8 +23063,16 @@ function apply(ctx, config = {}) {
 	ctx.inject([
 		"sessions",
 		"agents",
-		"agentDefaultModel"
+		"agentDefaultModel",
+		"settings"
 	], (runtimeCtx) => {
+		const themeSettings = runtimeCtx.reflect.get("settings", false)?.register(TUI_SETTINGS_NAMESPACE, TUI_SETTINGS_SCHEMA);
+		const storedTheme = themeSettings?.get().theme;
+		const persistTheme = themeSettings === void 0 ? void 0 : (theme) => {
+			themeSettings.update({ theme }).catch((err) => {
+				console.warn("[tui-runner] failed to persist theme:", err);
+			});
+		};
 		const requestHostExit = () => {
 			const exit = runtimeCtx.reflect.get("appExit", false);
 			if (typeof exit === "function") exit(0);
@@ -22241,6 +23097,8 @@ function apply(ctx, config = {}) {
 			onRestart: () => {
 				teardown(true, true);
 			},
+			...storedTheme === void 0 ? {} : { theme: storedTheme },
+			...persistTheme === void 0 ? {} : { persistTheme },
 			...config.initialSessionId === void 0 ? {} : { initialSessionId: config.initialSessionId },
 			...config.editorKey === void 0 ? {} : { editorKey: config.editorKey },
 			...config.vimEnabled === void 0 ? {} : { vimEnabled: config.vimEnabled },

--- a/lib/types/commands/registry.d.ts
+++ b/lib/types/commands/registry.d.ts
@@ -141,6 +141,10 @@ export declare class SlashCommandRegistry {
  * 内置命令工厂依赖——TuiApp 私有能力注入（会话铸造、滚动区重置、面板显隐切换）。
  */
 export interface BuiltinCommandDeps {
+    /** /theme：保存已确认的主题名；无 settings 服务时省略。 */
+    persistTheme?(name: string): void;
+    /** /theme：主题确认后按新主题重放当前历史消息。 */
+    onThemeChanged?(): void;
     /** /session new：新建会话并挂载（TuiApp.newSession）。 */
     newSession(): Promise<SessionId>;
     /** /fork、/branch（A3）：分叉当前会话（复制历史）并切换（TuiApp.forkSession）。 */

--- a/lib/types/ui/app.d.ts
+++ b/lib/types/ui/app.d.ts
@@ -33,6 +33,8 @@ export interface TuiAppOptions {
     initialSessionId?: SessionId;
     /** 主题名；'auto' 走系统终端配色探测，缺省 'auto'。 */
     theme?: string;
+    /** 持久化已确认的主题名；由 runner 接入宿主 settings。 */
+    persistTheme?: (name: string) => void;
     /** 输入行为空时 Ctrl+C 的退出回调（raw-mode 下 Ctrl+C 是数据字节非 SIGINT）。 */
     onExit?: () => void;
     /** /restart 与更新后自动重启的回调（装配方负责 dispose + spawn 同 argv + 退出）。 */
@@ -157,6 +159,7 @@ export declare class TuiApp {
     private ownedHandle;
     private readonly initialSessionId;
     private readonly themeName;
+    private readonly persistTheme;
     private readonly onExit;
     private readonly onRestart;
     /** 外部编辑器触发键（Phase 6.4）；缺省 ctrl_e（ctrl+o 已恢复为推理展开）。 */
@@ -676,6 +679,10 @@ export declare class TuiApp {
      * @param rows - RenderedRow 数组。
      */
     private commitRows;
+    /** 当前主题变化后，清理终端并用最新颜色重放当前会话历史。 */
+    private rerenderHistory;
+    /** 生成当前会话历史消息的主题化渲染行。 */
+    private renderHistoryRows;
     /**
      * 流式事件供给：assistant text-delta 推进 blockWriter（节流切块，稳定前缀
      * commit 进 scrollback）；message/turn 边界 flush + finalize 收尾。aborted

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -260,6 +260,10 @@ export class SlashCommandRegistry {
  * 内置命令工厂依赖——TuiApp 私有能力注入（会话铸造、滚动区重置、面板显隐切换）。
  */
 export interface BuiltinCommandDeps {
+  /** /theme：保存已确认的主题名；无 settings 服务时省略。 */
+  persistTheme?(name: string): void
+  /** /theme：主题确认后按新主题重放当前历史消息。 */
+  onThemeChanged?(): void
   /** /session new：新建会话并挂载（TuiApp.newSession）。 */
   newSession(): Promise<SessionId>
   /** /fork、/branch（A3）：分叉当前会话（复制历史）并切换（TuiApp.forkSession）。 */
@@ -325,7 +329,11 @@ export function createBuiltinCommands(deps: BuiltinCommandDeps): SlashCommand[] 
           deps.openThemePicker()
           return
         }
-        if (setTheme(name)) echo(`主题已切换: ${name}`)
+        if (setTheme(name)) {
+          deps.persistTheme?.(name)
+          deps.onThemeChanged?.()
+          echo(`主题已切换: ${name}`)
+        }
         else echo(`未知主题: ${name}。可用: ${THEME_NAMES.join(', ')}`)
       },
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@
 
 import { fileURLToPath } from 'node:url'
 import type { Context } from '@deepseek-ai/cordis'
+import z from '@deepseek-ai/schemastery'
+import { settingsNamespace } from '@deepseek-ai/dsh-settings'
 import type { ReadStream, WriteStream } from 'node:tty'
 import type { SessionId } from '@deepseek-ai/dsh-session'
 import type { KeyName } from './engine/input-handler.ts'
@@ -20,6 +22,11 @@ import { TuiApp } from './ui/app.ts'
 
 /** Stable Cordis plugin name the bundle patch inserts. */
 export const name = 'tui-runner'
+
+const TUI_SETTINGS_NAMESPACE = settingsNamespace('tui-runner')
+const TUI_SETTINGS_SCHEMA = z.object({
+  theme: z.string().default('auto'),
+})
 
 /** 装配选项：流与起始会话可注入（测试替身），缺省走 process 全局流。 */
 export interface TuiRunnerConfig {
@@ -78,7 +85,7 @@ export function apply(ctx: Context, config: TuiRunnerConfig = {}): void {
   process.on('exit', () => {
     try { if (stdin.isTTY && typeof stdin.setRawMode === 'function') stdin.setRawMode(false) } catch { /* best-effort */ }
   })
-  // 服务隔离：sessions/agents/agentDefaultModel 是注入属性，访问前必须
+  // 服务隔离：sessions/agents/agentDefaultModel/settings 是注入属性，访问前必须
   // 声明依赖（Cordis 4 注入语义，未声明访问抛 "without inject"；web-app 同款
   // 模式）。cmdlineArgs/appExit 是 launcher 在 boot prepare 里 provide 的宿主服务，
   // **不加入必选 inject**：Cordis inject 要求全部服务可用才执行回调，宿主未提供时
@@ -88,7 +95,22 @@ export function apply(ctx: Context, config: TuiRunnerConfig = {}): void {
   // TUI 静默不启动）：一律经 reflect.get 读取，/goal 命令与委派树在服务缺失时
   // 报不可用/面板降级（fails loud），但不阻塞装配。
   // 装配与 attach 在注入作用域内执行；生命周期仍注册在外层插件 ctx（随插件卸载）。
-  ctx.inject(['sessions', 'agents', 'agentDefaultModel'], (runtimeCtx) => {
+  ctx.inject(['sessions', 'agents', 'agentDefaultModel', 'settings'], (runtimeCtx) => {
+    const settings = runtimeCtx.reflect.get('settings', false) as {
+      register<T>(
+        ns: typeof TUI_SETTINGS_NAMESPACE,
+        schema: typeof TUI_SETTINGS_SCHEMA,
+      ): { get(): T; update(patch: object): Promise<void> }
+    } | undefined
+    const themeSettings = settings?.register<{ theme: string }>(TUI_SETTINGS_NAMESPACE, TUI_SETTINGS_SCHEMA)
+    const storedTheme = themeSettings?.get().theme
+    const persistTheme = themeSettings === undefined
+      ? undefined
+      : (theme: string): void => {
+        void themeSettings.update({ theme }).catch((err: unknown) => {
+          console.warn('[tui-runner] failed to persist theme:', err)
+        })
+      }
     // 退出生命周期：stdin SIGINT、Ctrl+C 空输入（onExit）与插件卸载（effect cleanup）
     // 都 await dispose（flushAll + 恢复终端）。用户主动退出（Ctrl+Q / /exit /
     // SIGINT）在 dispose 之后还要让宿主进程退出——否则 InputHandler 已 pause
@@ -120,6 +142,8 @@ export function apply(ctx: Context, config: TuiRunnerConfig = {}): void {
       stdout,
       onExit: () => { void teardown(true) },
       onRestart: () => { void teardown(true, true) },
+      ...(storedTheme === undefined ? {} : { theme: storedTheme }),
+      ...(persistTheme === undefined ? {} : { persistTheme }),
       ...(config.initialSessionId === undefined ? {} : { initialSessionId: config.initialSessionId }),
       ...(config.editorKey === undefined ? {} : { editorKey: config.editorKey }),
       ...(config.vimEnabled === undefined ? {} : { vimEnabled: config.vimEnabled }),

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -307,6 +307,8 @@ export interface TuiAppOptions {
   initialSessionId?: SessionId
   /** 主题名；'auto' 走系统终端配色探测，缺省 'auto'。 */
   theme?: string
+  /** 持久化已确认的主题名；由 runner 接入宿主 settings。 */
+  persistTheme?: (name: string) => void
   /** 输入行为空时 Ctrl+C 的退出回调（raw-mode 下 Ctrl+C 是数据字节非 SIGINT）。 */
   onExit?: () => void
   /** /restart 与更新后自动重启的回调（装配方负责 dispose + spawn 同 argv + 退出）。 */
@@ -582,6 +584,7 @@ export class TuiApp {
   private ownedHandle: AgentHandle | null = null
   private readonly initialSessionId: SessionId | undefined
   private readonly themeName: string
+  private readonly persistTheme: ((name: string) => void) | undefined
   private readonly onExit: (() => void) | undefined
   private readonly onRestart: (() => void) | undefined
   /** 外部编辑器触发键（Phase 6.4）；缺省 ctrl_e（ctrl+o 已恢复为推理展开）。 */
@@ -714,6 +717,7 @@ export class TuiApp {
     this.stdin = options.stdin
     this.initialSessionId = options.initialSessionId
     this.themeName = options.theme ?? 'auto'
+    this.persistTheme = options.persistTheme
     this.onExit = options.onExit
     this.onRestart = options.onRestart
     this.editorKey = options.editorKey ?? 'ctrl_e'
@@ -775,6 +779,8 @@ export class TuiApp {
     // T2.1/T2.2/T2.3：/tasks（含 kill 子命令）、/subagents、/workflow 的命令定义在
     // createBuiltinCommands（registry 维度），TuiApp 只注入显隐切换 deps。
     for (const command of createBuiltinCommands({
+      persistTheme: name => { this.persistTheme?.(name) },
+      onThemeChanged: () => { this.rerenderHistory() },
       newSession: () => this.newSession(),
       forkSession: () => this.forkSession(),
       switchLiveModel: selection => this.switchLiveModel(selection),
@@ -1775,8 +1781,8 @@ export class TuiApp {
     }))
     const selectedIndex = Math.max(0, THEME_NAMES.indexOf(prev as ThemeName))
     picker.open('选择主题', items, (item) => {
-      // 确认：主题已在预览中生效，此处只落提示。
-      this.commitToScrollback({ text: `主题已切换: ${item.value}`, trailingNewline: true })
+      // 确认：主题已在预览中生效；历史重放在 overlay 退出后执行。
+      this.persistTheme?.(item.value)
     }, selectedIndex, {
       // ↑↓ 移动即切换（实时预览，overlay 渲染随主题色即时变化）。
       onPreview: (item) => { setTheme(item.value) },
@@ -2047,21 +2053,7 @@ export class TuiApp {
     // 历史加载：重放会话事件日志（live store 为权威来源，persisted-only 走
     // loadHistory——见 adapter/sessions；此处 live store 已含全部事件）。
     // 工具卡走同一 presenter 桥（presenter 为 args 纯函数、桥软降级，replay 安全）。
-    const rows = renderTranscript(this.transcript.view, this.theme, this.stdout.columns, {
-      compact: this.compactMode,
-      resolveViews: (tool: TranscriptToolCall) => resolveToolViews(this.toolPresenters(), {
-        name: tool.name,
-        argumentsRaw: tool.arguments,
-        ...(tool.result === undefined ? {} : {
-          result: {
-            content: tool.result.data.message.content[0].content,
-            isError: toolResultText(tool.result).isError,
-            ...(tool.result.data.meta === undefined ? {} : { meta: tool.result.data.meta }),
-          },
-        }),
-      }),
-    })
-    this.commitRows(rows)
+    this.commitRows(this.renderHistoryRows())
     this.inputLine.setHistory(this.history)
     // T2.1：委派树预取（listDescendants 是 async——首次 await 入缓存；
     // subagent/start|end 事件触发 re-await + renderLive 刷新）。
@@ -2858,6 +2850,9 @@ export class TuiApp {
       } else if (key.name === 'return') {
         picker.commit()
         this.overlay.deactivate()
+        this.rerenderHistory()
+        this.commitToScrollback({ text: `主题已切换: ${getActiveThemeName()}`, trailingNewline: true })
+        this.flushLiveRender()
       }
       return
     }
@@ -3188,6 +3183,39 @@ export class TuiApp {
     const buf: string[] = []
     for (const row of rows) buf.push(row.ansi)
     this.commitToScrollback({ text: buf.join('\n'), trailingNewline: true })
+  }
+
+  /** 当前主题变化后，清理终端并用最新颜色重放当前会话历史。 */
+  private rerenderHistory(): void {
+    if (this.disposed || (this.overlay !== null && this.overlay.activeId() !== null)) return
+    // Theme changes must not turn a previously collapsed live reasoning block
+    // into a full-text block while the screen is being rebuilt.
+    this.reasoningExpanded = false
+    this.commit.reset()
+    this.live.reset()
+    this.stdout.write(`${ANSI.ERASE_SCREEN}\x1b[3J\x1b[H`)
+    this.commitRows(this.renderHistoryRows())
+    this.flushLiveRender()
+  }
+
+  /** 生成当前会话历史消息的主题化渲染行。 */
+  private renderHistoryRows(): RenderedRow[] {
+    const transcript = this.transcript
+    if (transcript === null) return []
+    return renderTranscript(transcript.view, this.theme, this.stdout.columns, {
+      compact: this.compactMode,
+      resolveViews: (tool: TranscriptToolCall) => resolveToolViews(this.toolPresenters(), {
+        name: tool.name,
+        argumentsRaw: tool.arguments,
+        ...(tool.result === undefined ? {} : {
+          result: {
+            content: tool.result.data.message.content[0].content,
+            isError: toolResultText(tool.result).isError,
+            ...(tool.result.data.meta === undefined ? {} : { meta: tool.result.data.meta }),
+          },
+        }),
+      }),
+    })
   }
 
   /**

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -93,7 +93,9 @@ export function renderMessageRows(
   options: RenderTranscriptOptions = {},
 ): RenderedRow[] {
   if (message.kind === 'user') {
-    return formatUserMessage({ content: message.text, width: columns, timestamp: message.time }, theme)
+    const content = stripSystemReminders(message.text)
+    if (content === '') return []
+    return formatUserMessage({ content, width: columns, timestamp: message.time }, theme)
       .map(ansi => ({ ansi, kind: 'user' as const }))
   }
   const rows: RenderedRow[] = []
@@ -106,6 +108,14 @@ export function renderMessageRows(
   rows.push(...formatMarkdown({ text: message.text, columns }, theme)
     .map(ansi => ({ ansi, kind: 'assistant' as const })))
   return rows
+}
+
+/** System reminders are runtime instructions, not conversation content. */
+function stripSystemReminders(text: string): string {
+  return text
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/gi, '')
+    .replace(/Current runtime context\.[\s\S]*?Approval policy:[\s\S]*?fail(?:s)? closed\.\s*/gi, '')
+    .trim()
 }
 
 /**

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -4089,7 +4089,16 @@ describe('TuiApp 结算卡与推理通道', () => {
     expect(expanded).toContain('✻ 思考')
     expect(expanded).toContain('ctrl+o 收起')
 
-    // 再按一次收起：正文从 live 区消失。
+    // Theme replay must not retain the transient expanded reasoning view.
+    stdout.write.mockClear()
+    app.handleSubmit('/theme paper')
+    await new Promise(resolve => setTimeout(resolve, 60))
+    const themed = stdout.write.mock.calls.map(c => `${c[0]}`).join('')
+    expect(themed).not.toContain('ctrl+o 收起')
+
+    // Theme replay resets the transient expansion; re-open it, then collapse it.
+    stdin.emit('data', '\x0f')
+    await new Promise(resolve => setTimeout(resolve, 60))
     stdout.write.mockClear()
     stdin.emit('data', '\x0f')
     await new Promise(resolve => setTimeout(resolve, 60))

--- a/tests/commands.spec.ts
+++ b/tests/commands.spec.ts
@@ -58,6 +58,8 @@ function makeArgs(overrides: Partial<Parameters<ReturnType<typeof createBuiltinC
 
 function commandByName(name: string) {
   const deps = {
+    persistTheme: vi.fn(),
+    onThemeChanged: vi.fn(),
     newSession: vi.fn(),
     forkSession: vi.fn(),
     switchLiveModel: vi.fn(() => true),
@@ -212,10 +214,12 @@ describe('SlashCommandRegistry — 注册/列举/解析', () => {
 
 describe('内置命令 — /theme', () => {
   it('有效主题名切换并回显', async () => {
-    const { cmd } = commandByName('theme')
+    const { cmd, deps } = commandByName('theme')
     const { args, echo } = makeArgs({ text: 'paper' })
     await cmd.run(args)
     expect(getActiveThemeName()).toBe('paper')
+    expect(deps.persistTheme).toHaveBeenCalledWith('paper')
+    expect(deps.onThemeChanged).toHaveBeenCalledTimes(1)
     expect(echo).toHaveBeenCalledWith('主题已切换: paper')
   })
 

--- a/tests/render.spec.ts
+++ b/tests/render.spec.ts
@@ -133,6 +133,23 @@ describe('renderMessageRows', () => {
     expect(plain(rows).join('\n')).toContain('你好世界')
   })
 
+  it('user 消息隐藏运行时 system-reminder，只保留真实用户内容', () => {
+    const rows = renderMessageRows(userMessage('<system-reminder>内部规则</system-reminder>请查看项目'), fakeTheme(), 80)
+    const text = plain(rows).join('\n')
+    expect(text).toContain('请查看项目')
+    expect(text).not.toContain('内部规则')
+    expect(text).not.toContain('system-reminder')
+  })
+
+  it('user 消息隐藏未包裹标签的 runtime context', () => {
+    const rows = renderMessageRows(userMessage('你好\nCurrent runtime context. This snapshot supersedes earlier runtime-context snapshots.\nCurrent DSH file policy: workspace-write.\nApproval policy: ask. Operations fail closed.\n'), fakeTheme(), 80)
+    const text = plain(rows).join('\n')
+    expect(text).toContain('你好')
+    expect(text).not.toContain('Current runtime context')
+    expect(text).not.toContain('workspace-write')
+    expect(text).not.toContain('Approval policy')
+  })
+
   it('assistant 消息 → formatMarkdown 行，kind assistant', () => {
     const rows = renderMessageRows(assistantMessage('回答内容'), fakeTheme(), 80)
     expect(rows.every(r => r.kind === 'assistant')).toBe(true)


### PR DESCRIPTION
## Summary

- persist the selected theme in the host settings and restore it after plugin restart
- rerender committed transcript history with the active theme after switching
- keep reasoning collapsed and hide runtime system reminders during history replay

## Tests

- `npm test`
- `npm run typecheck`
- `npm run build`