### PR TITLE
fix(deps): 对齐 dsh-lsp 的 dsh-tools 版本线，消除多副本 Symbol 错位崩溃

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@huiliyi37/dsh-lsp",
   "description": "dsh-lsp: LSP model tool surface for the DeepSeek Harness — goto-definition / find-references / diagnostics tools + a shared 'lsp' service consumed by the dsh-tianshu-tui display bridge (single LSP server set, no double spawn)",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@deepseek-ai/dsh-tools": "^0.0.1-rc.1",
+    "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
     "@deepseek-ai/schemastery": "^3.18.1"
   },
   "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@huiliyi37/dsh-tianshu-tui",
-  "version": "0.1.2-rc.21",
+  "version": "0.1.2-rc.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@huiliyi37/dsh-tianshu-tui",
-      "version": "0.1.2-rc.21",
+      "version": "0.1.2-rc.22",
       "license": "Apache-2.0",
       "dependencies": {
         "@deepseek-ai/dsh-agent-presets": "0.1.1-rc.2",
-        "@huiliyi37/dsh-lsp": "0.1.0-rc.1",
+        "@huiliyi37/dsh-lsp": "0.1.0-rc.2",
         "chalk": "^6.0.0",
         "diff": "^9.0.0",
         "get-east-asian-width": "^1.6.0",
@@ -463,7 +463,6 @@
       "version": "0.1.0-rc.8",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.0-rc.8.tgz",
       "integrity": "sha512-tvuGAVUS4yoPW9zH7CGWJgMlAzGjfu2UlRiricldlcwSKAaJZPZx/K/YfTivUyDTER6aK1DJUnIpVG7RD/DoHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
@@ -549,36 +548,16 @@
       }
     },
     "node_modules/@huiliyi37/dsh-lsp": {
-      "version": "0.1.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@huiliyi37/dsh-lsp/-/dsh-lsp-0.1.0-rc.1.tgz",
-      "integrity": "sha512-N+7wVgpOBNOYCJaH3uI3GyXjdChIdv17BhTUWGzUI5zsKvpOQgoD3VZeA3s3i4n/fV4ASMxi2JvttHRBdqRjyw==",
+      "version": "0.1.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@huiliyi37/dsh-lsp/-/dsh-lsp-0.1.0-rc.2.tgz",
+      "integrity": "sha512-REGENERATE-AFTER-PUBLISHING-dsh-lsp-0.1.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@deepseek-ai/dsh-tools": "^0.0.1-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.0-rc.8",
         "@deepseek-ai/schemastery": "^3.18.1"
       },
       "engines": {
         "node": "^22.19 || >=24"
-      }
-    },
-    "node_modules/@huiliyi37/dsh-lsp/node_modules/@deepseek-ai/dsh-tools": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.0.1-rc.1.tgz",
-      "integrity": "sha512-mrtq+UXc6UVidrGo4GM8RAH0Gqc4iFOmtPeQAz59Phhjl3EmzkFI0Mo6dQlHQamrc2J9jppPtGtUzW9qHmwxDQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1-rc.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-agent": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-code-runtime": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-user-approval": "^0.0.1-rc.1"
       }
     },
     "node_modules/@img/colour": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@deepseek-ai/dsh-agent-presets": "0.1.1-rc.2",
-    "@huiliyi37/dsh-lsp": "0.1.0-rc.1",
+    "@huiliyi37/dsh-lsp": "0.1.0-rc.2",
     "chalk": "^6.0.0",
     "diff": "^9.0.0",
     "get-east-asian-width": "^1.6.0",


### PR DESCRIPTION
## 问题

`dsh --profile tui` 在 agent 执行模型返回的工具调用时偶发崩溃：

```
Cannot read properties of undefined (reading 'prepare')
```

崩溃点在 `@deepseek-ai/dsh-agent-loop/lib/index.js:193`：

```js
const prepared = await ctx.tools[TOOL_RUNTIME_SCHEDULER].prepare(call.exec);
```

`ctx.tools[TOOL_RUNTIME_SCHEDULER]` 为 `undefined`。`TOOL_RUNTIME_SCHEDULER` 在
`@deepseek-ai/dsh-tools/lib/index.js:2409` 定义为 `Symbol(...)`——每次加载产生
互不相等的 Symbol。只要 agent-loop 与注册 ToolRuntime 的模块各自加载了不同副本
的 dsh-tools，查表即落空。

崩溃后该工具调用在会话日志里变成「悬挂 tool_call」（有 tool/call 无 tool/result），
任何 resume/retry 都被 DeepSeek OpenAI 兼容接口 400 拒绝（`insufficient tool messages`），
会话永久卡死。

## 根因

当前 profile 依赖树里同时存在多份不同版本的 `@deepseek-ai/dsh-tools`，其中
`@huiliyi37/dsh-lsp@0.1.0-rc.1` 把 dsh-tools 精确钉在 `^0.0.1-rc.1`（0.0.x 线），
被 pnpm hoist 到根，与 agent-loop 用的 `0.1.0-rc.6` 产生 Symbol 错位：

```
@huiliyi37/dsh-tianshu-tui@0.1.2-rc.22
  └─ @huiliyi37/dsh-lsp@0.1.0-rc.1          (package.json:110)
       └─ @deepseek-ai/dsh-tools: ^0.0.1-rc.1  ← 0.0.x 老线，分叉根源
```

## 修复

1. `lsp/package.json`：`@deepseek-ai/dsh-tools` 从 `^0.0.1-rc.1` 改为 `^0.1.0-rc.8`
   （与 tui/底座一致），消除版本分叉，让 pnpm 复用单一副本。
2. `lsp/package.json`：版本 bump `0.1.0-rc.1` → `0.1.0-rc.2`。
3. 根 `package.json`：`@huiliyi37/dsh-lsp` 依赖指向 `0.1.0-rc.2`。
4. 根 `package-lock.json` 重算：删除嵌套的
   `@huiliyi37/dsh-lsp/node_modules/@deepseek-ai/dsh-tools@0.0.1-rc.1` 条目，
   dsh-tools 收敛到根 `0.1.0-rc.8`（顺带修正 lockfile 版本字段 rc.21 → rc.22 的
   历史漂移）。

## 验证

- `npm install --package-lock-only --legacy-peer-deps`：确认 lsp 改用
  `^0.1.0-rc.8` 后 dsh-tools 去重到单份 `0.1.0-rc.8`，嵌套 `0.0.1-rc.1` 条目消失。
- `npm run lint`：0 error（1 个与本次无关的既有 warning）。
- `npm ci --dry-run --legacy-peer-deps`：lockfile 结构一致。

## ⚠️ 合并前须知

`@huiliyi37/dsh-lsp@0.1.0-rc.2` 尚未发布到 npm。合并前需先：

1. 按本 PR 的 `lsp/package.json` 发布 `@huiliyi37/dsh-lsp@0.1.0-rc.2`（含
   `dsh-tools@^0.1.0-rc.8`）。
2. 发布后执行 `npm install --legacy-peer-deps` 重新生成 lockfile，替换本 PR 里
   `@huiliyi37/dsh-lsp` 条目的占位 integrity（当前为
   `sha512-REGENERATE-AFTER-PUBLISHING-dsh-lsp-0.1.0-rc.2`）。

在此之前 CI 的 `npm ci` 步骤会因该版本缺失而失败，属预期。